### PR TITLE
Make pulsar-common required and improve error logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,6 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-common</artifactId>
       <version>${pulsar.version}</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Error running this sink connector.

```
java.lang.NoClassDefFoundError: org/apache/pulsar/common/naming/TopicName
	at org.apache.pulsar.io.jcloud.partitioner.Partitioner.generatePartitionedPath(Partitioner.java:61) ~[pulsar-io-cloud-storage-2.8.0-rc-202105251229.nar-unpacked/:?]
	at org.apache.pulsar.io.jcloud.sink.BlobStoreAbstractSink.buildPartitionPath(BlobStoreAbstractSink.java:229) ~[pulsar-io-cloud-storage-2.8.0-rc-202105251229.nar-unpacked/:?]
	at org.apache.pulsar.io.jcloud.sink.BlobStoreAbstractSink.unsafeFlush(BlobStoreAbstractSink.java:196) ~[pulsar-io-cloud-storage-2.8.0-rc-202105251229.nar-unpacked/:?]
	at org.apache.pulsar.io.jcloud.sink.BlobStoreAbstractSink.flush(BlobStoreAbstractSink.java:167) ~[pulsar-io-cloud-storage-2.8.0-rc-202105251229.nar-unpacked/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_275]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_275]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_275]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275]
```