### PR TITLE
Save message attributes to metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The Cloud Storage sink connector supports the following properties.
 | `timePartitionDuration` | String| False |"1d" | The time interval for time-based partitioning, such as 1d, or 1h. |
 | `batchSize` | int | False |10 | The number of records submitted in batch. |
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
+| `useMetadata` | Boolean | False |false | Save message attributes to metadata. |
 
 ## Configure Cloud Storage sink connector
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Cloud Storage sink connector supports the following properties.
 | `timePartitionDuration` | String| False |"1d" | The time interval for time-based partitioning, such as 1d, or 1h. |
 | `batchSize` | int | False |10 | The number of records submitted in batch. |
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
-| `useMetadata` | Boolean | False |false | Save message attributes to metadata. |
+| `withMetadata` | Boolean | False |false | Save message attributes to metadata. |
 
 ## Configure Cloud Storage sink connector
 

--- a/pom.xml
+++ b/pom.xml
@@ -366,13 +366,6 @@
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- for apple Apple Silicon (M1, Mac-aarch64)-->
-    <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>1.1.8.4</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,13 @@
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- for apple Apple Silicon (M1, Mac-aarch64)-->
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.8.4</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -86,7 +86,7 @@ public class BlobStoreAbstractConfig implements Serializable {
 
     private long batchTimeMs = 1000;
 
-    private boolean useMetadata;
+    private boolean withMetadata;
 
     public void validate() {
         checkNotNull(bucket, "bucket property not set.");

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -86,6 +86,7 @@ public class BlobStoreAbstractConfig implements Serializable {
 
     private long batchTimeMs = 1000;
 
+    private boolean useMetadata;
 
     public void validate() {
         checkNotNull(bucket, "bucket property not set.");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -54,7 +54,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
 
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
-        this.useMetadata = configuration.isUseMetadata();
+        this.useMetadata = configuration.isWithMetadata();
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -21,9 +21,7 @@ package org.apache.pulsar.io.jcloud.format;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteSource;
 import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
@@ -78,14 +76,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
 
                 if (useMetadata) {
-                    Map<String, Object> metadata = MetadataUtil.extractedMetadata(next);
-                    metadata.forEach((key, v) -> {
-                        if (v instanceof byte[]){
-                            writeRecord.put(key, ByteBuffer.wrap((byte[]) v));
-                        } else {
-                            writeRecord.put(key, v);
-                        }
-                    });
+                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next);
+                    writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 fileWriter.append(writeRecord);
             }

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/BytesFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/BytesFormat.java
@@ -32,7 +32,7 @@ import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 /**
  * bytes format.
  */
-public class BytesFormat implements Format<GenericRecord>, InitConfiguration {
+public class BytesFormat implements Format<GenericRecord>, InitConfiguration<BlobStoreAbstractConfig> {
 
     private byte[] lineSeparatorBytes;
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -48,7 +48,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
 
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
-        this.useMetadata = configuration.isUseMetadata();
+        this.useMetadata = configuration.isWithMetadata();
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -29,17 +29,26 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
+import org.apache.pulsar.io.jcloud.util.MetadataUtil;
 
 /**
  * json format.
  */
-public class JsonFormat implements Format<GenericRecord> {
+public class JsonFormat implements Format<GenericRecord>, InitConfiguration<BlobStoreAbstractConfig> {
 
     private ObjectMapper objectMapper;
+
+    private boolean useMetadata;
 
     @Override
     public String getExtension() {
         return ".json";
+    }
+
+    @Override
+    public void configure(BlobStoreAbstractConfig configuration) {
+        this.useMetadata = configuration.isUseMetadata();
     }
 
     @Override
@@ -52,7 +61,10 @@ public class JsonFormat implements Format<GenericRecord> {
         StringBuilder stringBuilder = new StringBuilder();
         if (record.hasNext()) {
             Record<GenericRecord> next = record.next();
-            Object writeValue = convertRecordToObject(next.getValue());
+            Map<String, Object> writeValue = convertRecordToObject(next.getValue());
+            if (useMetadata) {
+                writeValue.putAll(MetadataUtil.extractedMetadata(next));
+            }
             String recordAsString = objectMapper.writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");
         }

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -63,7 +63,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             Record<GenericRecord> next = record.next();
             Map<String, Object> writeValue = convertRecordToObject(next.getValue());
             if (useMetadata) {
-                writeValue.putAll(MetadataUtil.extractedMetadata(next));
+                writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY, MetadataUtil.extractedMetadata(next));
             }
             String recordAsString = objectMapper.writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -53,7 +53,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
 
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
-        this.useMetadata = configuration.isUseMetadata();
+        this.useMetadata = configuration.isWithMetadata();
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -21,9 +21,7 @@ package org.apache.pulsar.io.jcloud.format;
 
 import com.google.common.io.ByteSource;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -85,14 +83,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                 org.apache.avro.generic.GenericRecord writeRecord = AvroRecordUtil
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
                 if (useMetadata) {
-                    final Map<String, Object> metadata = MetadataUtil.extractedMetadata(next);
-                    metadata.forEach((key, v) -> {
-                        if (v instanceof byte[]){
-                            writeRecord.put(key, ByteBuffer.wrap((byte[]) v));
-                        } else {
-                            writeRecord.put(key, v);
-                        }
-                    });
+                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next);
+                    writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 parquetWriter.write(writeRecord);
             }

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
@@ -68,6 +68,9 @@ public class AvroRecordUtil {
     public static org.apache.pulsar.client.api.Schema<GenericRecord> extractPulsarSchema(
             Message<GenericRecord> message) {
         try {
+            if (message.getReaderSchema().isPresent()) {
+                return (org.apache.pulsar.client.api.Schema<GenericRecord>) message.getReaderSchema().get();
+            }
             //There is no good way to handle `PulsarRecord#getSchema` in the pulsar function,
             // first read the schema information in the Message through reflection.
             // You can replace this method when the schema is available in the Record.
@@ -102,6 +105,11 @@ public class AvroRecordUtil {
 
     public static org.apache.avro.generic.GenericRecord convertGenericRecord(GenericRecord recordValue,
                                                                              Schema rootAvroSchema) {
+        return convertGenericRecord(recordValue, rootAvroSchema, false);
+    }
+    public static org.apache.avro.generic.GenericRecord convertGenericRecord(GenericRecord recordValue,
+                                                                             Schema rootAvroSchema,
+                                                                             boolean useMetadata) {
         org.apache.avro.generic.GenericRecord recordHolder = new GenericData.Record(rootAvroSchema);
         for (org.apache.pulsar.client.api.schema.Field field : recordValue.getFields()) {
             Schema.Field field1 = rootAvroSchema.getField(field.getName());

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.functions.api.Record;
+
+/**
+ * metadata util.
+ */
+public class MetadataUtil {
+
+    public static final String METADATA_ORIGIN_SCHEMA_KEY = "__originSchema";
+    public static final String METADATA_ORIGIN_PROPERTIES_KEY = "__originProperties";
+    public static final String METADATA_ORIGIN_SCHEMA_VERSION_KEY = "__originSchemaVersion";
+    public static final String METADATA_MESSAGE_ID_KEY = "__messageId";
+
+    public static Map<String, Object> extractedMetadata(Record<GenericRecord> next) {
+        Map<String, Object> metadata = new HashMap<>();
+        final Message<GenericRecord> message = next.getMessage().get();
+        final org.apache.pulsar.client.api.Schema<GenericRecord> recordSchema =
+                AvroRecordUtil.extractPulsarSchema(message);
+        final SchemaInfo schemaInfo = recordSchema.getSchemaInfo();
+        metadata.put(METADATA_ORIGIN_SCHEMA_KEY, schemaInfo.getSchema());
+        metadata.put(METADATA_ORIGIN_PROPERTIES_KEY, schemaInfo.getProperties());
+        metadata.put(METADATA_ORIGIN_SCHEMA_VERSION_KEY, message.getSchemaVersion());
+        metadata.put(METADATA_MESSAGE_ID_KEY, message.getMessageId().toByteArray());
+        return metadata;
+    }
+    public static Schema setMetadataSchema(Schema schema) {
+
+        final List<Schema.Field> fieldWithMetadata = new ArrayList<>();
+
+        schema.getFields().forEach(f -> {
+            fieldWithMetadata.add(new Schema.Field(f, f.schema()));
+        });
+
+        fieldWithMetadata.add(new Schema.Field(METADATA_ORIGIN_SCHEMA_KEY, Schema.create(Schema.Type.BYTES)));
+        fieldWithMetadata.add(new Schema.Field(METADATA_ORIGIN_PROPERTIES_KEY,
+                Schema.createUnion(
+                        Schema.create(Schema.Type.NULL),
+                        Schema.createMap(Schema.create(Schema.Type.STRING))
+                ))
+        );
+        fieldWithMetadata.add(new Schema.Field(METADATA_ORIGIN_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.BYTES)));
+        fieldWithMetadata.add(new Schema.Field(METADATA_MESSAGE_ID_KEY, Schema.create(Schema.Type.BYTES)));
+        return Schema.createRecord(schema.getName(),
+                schema.getDoc(),
+                schema.getNamespace(),
+                schema.isError(),
+                fieldWithMetadata
+                );
+    }
+}

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -35,9 +35,9 @@ import org.apache.pulsar.functions.api.Record;
  */
 public class MetadataUtil {
 
-    public static final String METADATA_ORIGIN_PROPERTIES_KEY = "__originProperties";
-    public static final String METADATA_ORIGIN_SCHEMA_VERSION_KEY = "__originSchemaVersion";
-    public static final String METADATA_MESSAGE_ID_KEY = "__messageId";
+    public static final String METADATA_ORIGIN_PROPERTIES_KEY = "originProperties";
+    public static final String METADATA_ORIGIN_SCHEMA_VERSION_KEY = "originSchemaVersion";
+    public static final String METADATA_MESSAGE_ID_KEY = "messageId";
     public static final String MESSAGE_METADATA_KEY = "__message_metadata__";
     public static final String MESSAGE_METADATA_NAME = "MessageMetadata";
     public static final Schema MESSAGE_METADATA = buildMetadataSchema();

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -35,11 +35,11 @@ import org.apache.pulsar.functions.api.Record;
  */
 public class MetadataUtil {
 
-    public static final String METADATA_ORIGIN_PROPERTIES_KEY = "originProperties";
-    public static final String METADATA_ORIGIN_SCHEMA_VERSION_KEY = "originSchemaVersion";
+    public static final String METADATA_PROPERTIES_KEY = "properties";
+    public static final String METADATA_SCHEMA_VERSION_KEY = "schemaVersion";
     public static final String METADATA_MESSAGE_ID_KEY = "messageId";
     public static final String MESSAGE_METADATA_KEY = "__message_metadata__";
-    public static final String MESSAGE_METADATA_NAME = "MessageMetadata";
+    public static final String MESSAGE_METADATA_NAME = "messageMetadata";
     public static final Schema MESSAGE_METADATA = buildMetadataSchema();
 
     private static ThreadLocal<List<Schema.Field>> schemaFieldThreadLocal = ThreadLocal.withInitial(ArrayList::new);
@@ -51,8 +51,8 @@ public class MetadataUtil {
         final SchemaInfo schemaInfo = recordSchema.getSchemaInfo();
 
         GenericData.Record record = new GenericData.Record(MESSAGE_METADATA);
-        record.put(METADATA_ORIGIN_PROPERTIES_KEY, schemaInfo.getProperties());
-        record.put(METADATA_ORIGIN_SCHEMA_VERSION_KEY, ByteBuffer.wrap(message.getSchemaVersion()));
+        record.put(METADATA_PROPERTIES_KEY, schemaInfo.getProperties());
+        record.put(METADATA_SCHEMA_VERSION_KEY, ByteBuffer.wrap(message.getSchemaVersion()));
         record.put(METADATA_MESSAGE_ID_KEY, ByteBuffer.wrap(message.getMessageId().toByteArray()));
         return record;
     }
@@ -63,8 +63,8 @@ public class MetadataUtil {
         final org.apache.pulsar.client.api.Schema<GenericRecord> recordSchema =
                 AvroRecordUtil.extractPulsarSchema(message);
         final SchemaInfo schemaInfo = recordSchema.getSchemaInfo();
-        metadata.put(METADATA_ORIGIN_PROPERTIES_KEY, schemaInfo.getProperties());
-        metadata.put(METADATA_ORIGIN_SCHEMA_VERSION_KEY, message.getSchemaVersion());
+        metadata.put(METADATA_PROPERTIES_KEY, schemaInfo.getProperties());
+        metadata.put(METADATA_SCHEMA_VERSION_KEY, message.getSchemaVersion());
         metadata.put(METADATA_MESSAGE_ID_KEY, message.getMessageId().toByteArray());
 
 
@@ -87,13 +87,13 @@ public class MetadataUtil {
 
     private static Schema buildMetadataSchema(){
         List<Schema.Field> fields = new ArrayList<>();
-        fields.add(new Schema.Field(METADATA_ORIGIN_PROPERTIES_KEY,
+        fields.add(new Schema.Field(METADATA_PROPERTIES_KEY,
                 Schema.createUnion(
                         Schema.create(Schema.Type.NULL),
                         Schema.createMap(Schema.create(Schema.Type.STRING))
                 ))
         );
-        fields.add(new Schema.Field(METADATA_ORIGIN_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.BYTES)));
+        fields.add(new Schema.Field(METADATA_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.BYTES)));
         fields.add(new Schema.Field(METADATA_MESSAGE_ID_KEY, Schema.create(Schema.Type.BYTES)));
         return Schema.createRecord(MESSAGE_METADATA_NAME,
                 null,

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
@@ -67,7 +67,7 @@ public class AvroFormatTest extends FormatTestBase {
         try {
             final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
             final BlobStoreAbstractConfig config = new BlobStoreAbstractConfig();
-            config.setUseMetadata(true);
+            config.setWithMetadata(true);
             ((InitConfiguration<BlobStoreAbstractConfig>) getFormat()).configure(config);
             getFormat().initSchema(schema);
             ByteSource byteSource = getFormat().recordWriter(records.listIterator());

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
@@ -31,10 +31,8 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.SinkRecord;
 import org.apache.pulsar.functions.source.PulsarRecord;
-import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 import org.apache.pulsar.io.jcloud.util.AvroRecordUtil;
 import org.apache.pulsar.io.jcloud.util.MetadataUtil;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +53,13 @@ public class AvroFormatTest extends FormatTestBase {
         return ".avro";
     }
 
-    public void handleMessage(TopicName topicName, Message<GenericRecord> msg) {
+    @Override
+    protected boolean supportMetadata() {
+        return true;
+    }
+
+    public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
+                                                                          Message<GenericRecord> msg) throws Exception {
         @SuppressWarnings("unchecked")
         PulsarRecord<GenericRecord> test = PulsarRecord.<GenericRecord>builder()
                 .topicName(topicName.toString())
@@ -64,27 +68,16 @@ public class AvroFormatTest extends FormatTestBase {
                 .build();
         List<Record<GenericRecord>> records = new ArrayList<>();
         records.add(new SinkRecord<>(test, test.getValue()));
-        try {
-            final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
-            final BlobStoreAbstractConfig config = new BlobStoreAbstractConfig();
-            config.setWithMetadata(true);
-            ((InitConfiguration<BlobStoreAbstractConfig>) getFormat()).configure(config);
-            getFormat().initSchema(schema);
-            ByteSource byteSource = getFormat().recordWriter(records.listIterator());
 
+        final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
+        org.apache.avro.Schema avroSchema = AvroRecordUtil.convertToAvroSchema(schema);
+        avroSchema = MetadataUtil.setMetadataSchema(avroSchema);
 
-            final org.apache.avro.Schema avroSchema = AvroRecordUtil.convertToAvroSchema(schema);
-            final GenericDatumReader<Object> datumReader =
-                    new GenericDatumReader<>(MetadataUtil.setMetadataSchema(avroSchema));
-            final SeekableByteArrayInput input = new SeekableByteArrayInput(byteSource.read());
-            final DataFileReader<Object> objects = new DataFileReader<>(input, datumReader);
-
-            final org.apache.avro.generic.GenericRecord genericRecord =
-                    (org.apache.avro.generic.GenericRecord) objects.next();
-            assertEquals(msg.getValue(), genericRecord);
-        } catch (Exception e) {
-            log.error("", e);
-            Assert.fail();
-        }
+        final GenericDatumReader<Object> datumReader =
+                new GenericDatumReader<>(avroSchema);
+        ByteSource byteSource = getFormat().recordWriter(records.listIterator());
+        final SeekableByteArrayInput input = new SeekableByteArrayInput(byteSource.read());
+        final DataFileReader<Object> objects = new DataFileReader<>(input, datumReader);
+        return (org.apache.avro.generic.GenericRecord) objects.next();
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
@@ -82,8 +82,6 @@ public class AvroFormatTest extends FormatTestBase {
             final org.apache.avro.generic.GenericRecord genericRecord =
                     (org.apache.avro.generic.GenericRecord) objects.next();
             assertEquals(msg.getValue(), genericRecord);
-            System.out.println("build.record() = " + genericRecord);
-            System.out.println("record.getClass() = " + genericRecord.getClass());
         } catch (Exception e) {
             log.error("", e);
             Assert.fail();

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
@@ -70,7 +70,6 @@ public class BytesFormatTest extends FormatTestBase {
 
             final byte[] expecteds =
                     ArrayUtils.addAll(msg.getData(), System.lineSeparator().getBytes(StandardCharsets.UTF_8));
-
             Assert.assertArrayEquals(expecteds, byteSource.read());
         } catch (Exception e) {
             log.error("", e);

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -180,8 +180,8 @@ public abstract class FormatTestBase extends PulsarTestBase {
 
         Assert.assertEquals(ByteBuffer.wrap(message.getMessageId().toByteArray()),
                 genericRecord.get(MetadataUtil.METADATA_MESSAGE_ID_KEY));
-        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_ORIGIN_PROPERTIES_KEY));
-        Map<Utf8, Utf8> utf8Utf8Map = (Map<Utf8, Utf8>) genericRecord.get(MetadataUtil.METADATA_ORIGIN_PROPERTIES_KEY);
+        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_PROPERTIES_KEY));
+        Map<Utf8, Utf8> utf8Utf8Map = (Map<Utf8, Utf8>) genericRecord.get(MetadataUtil.METADATA_PROPERTIES_KEY);
         Map<String, String> resultMap = utf8Utf8Map.entrySet().stream().collect(
                 Collectors.toMap(
                         e -> e.getKey().toString(),
@@ -193,9 +193,9 @@ public abstract class FormatTestBase extends PulsarTestBase {
                         message.getReaderSchema().get().getSchemaInfo().getProperties(),
                         resultMap
                 ));
-        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_ORIGIN_SCHEMA_VERSION_KEY));
+        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_SCHEMA_VERSION_KEY));
         Assert.assertEquals(ByteBuffer.wrap(message.getSchemaVersion()),
-                genericRecord.get(MetadataUtil.METADATA_ORIGIN_SCHEMA_VERSION_KEY));
+                genericRecord.get(MetadataUtil.METADATA_SCHEMA_VERSION_KEY));
     }
 
     public boolean mapsAreEqual(Map<String, String> mapA, Map<String, String> mapB) {

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -117,7 +117,7 @@ public abstract class FormatTestBase extends PulsarTestBase {
                     validMetadata(formatGeneratedRecord, msg);
                 }
             } catch (Exception e) {
-                LOGGER.error("", e);
+                LOGGER.error("formatter handle message is fail", e);
                 Assert.fail();
             }
         };

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pulsar.io.jcloud.format;
 
+import java.nio.ByteBuffer;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -34,8 +37,10 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 import org.apache.pulsar.io.jcloud.PulsarTestBase;
 import org.apache.pulsar.io.jcloud.bo.TestRecord;
+import org.apache.pulsar.io.jcloud.util.MetadataUtil;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -82,9 +87,7 @@ public abstract class FormatTestBase extends PulsarTestBase {
 
         sendTypedMessages(avroTopicName.toString(), SchemaType.AVRO, testRecords, Optional.empty(), TestRecord.class);
 
-        Consumer<Message<GenericRecord>> handle = msg -> {
-            handleMessage(avroTopicName, msg);
-        };
+        Consumer<Message<GenericRecord>> handle = getMessageConsumer(avroTopicName);
         consumerMessages(avroTopicName.toString(), Schema.AUTO_CONSUME(), handle, testRecords.size(), 2000);
     }
 
@@ -97,13 +100,32 @@ public abstract class FormatTestBase extends PulsarTestBase {
 
         sendTypedMessages(jsonTopicName.toString(), SchemaType.AVRO, testRecords, Optional.empty(), TestRecord.class);
 
-        Consumer<Message<GenericRecord>> handle = msg -> {
-            handleMessage(jsonTopicName, msg);
-        };
+        Consumer<Message<GenericRecord>>
+                handle = getMessageConsumer(jsonTopicName);
         consumerMessages(jsonTopicName.toString(), Schema.AUTO_CONSUME(), handle, testRecords.size(), 2000);
     }
 
-    public abstract void handleMessage(TopicName topicName, Message<GenericRecord> msg);
+    protected abstract boolean supportMetadata();
+
+    private Consumer<Message<GenericRecord>> getMessageConsumer(TopicName topic) {
+        return msg -> {
+            try {
+                initSchema((Schema<GenericRecord>) msg.getReaderSchema().get());
+                org.apache.avro.generic.GenericRecord formatGeneratedRecord = getFormatGeneratedRecord(topic, msg);
+                assertEquals(msg.getValue(), formatGeneratedRecord);
+                if (supportMetadata()) {
+                    validMetadata(formatGeneratedRecord, msg);
+                }
+            } catch (Exception e) {
+                LOGGER.error("", e);
+                Assert.fail();
+            }
+        };
+    }
+
+    public abstract org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
+                                                                                   Message<GenericRecord> msg)
+            throws Exception;
 
     protected void assertEquals(GenericRecord msgValue, org.apache.avro.generic.GenericRecord record) {
         for (Field field : msgValue.getFields()) {
@@ -137,5 +159,61 @@ public abstract class FormatTestBase extends PulsarTestBase {
             }
         }
         return recordValue.getField(field);
+    }
+
+    private void initSchema(Schema<GenericRecord> schema) {
+        final BlobStoreAbstractConfig config = new BlobStoreAbstractConfig();
+        if (supportMetadata()) {
+            config.setWithMetadata(true);
+        }
+        ((InitConfiguration<BlobStoreAbstractConfig>) getFormat()).configure(config);
+        getFormat().initSchema(schema);
+    }
+
+    protected void validMetadata(org.apache.avro.generic.GenericRecord record, Message<GenericRecord> message) {
+        Object object = record.get(MetadataUtil.MESSAGE_METADATA_KEY);
+        Assert.assertNotNull(object);
+        Assert.assertTrue(object instanceof org.apache.avro.generic.GenericRecord);
+        org.apache.avro.generic.GenericRecord genericRecord = (org.apache.avro.generic.GenericRecord) object;
+        Assert.assertEquals(genericRecord.getSchema(), MetadataUtil.MESSAGE_METADATA);
+        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_MESSAGE_ID_KEY));
+
+        Assert.assertEquals(ByteBuffer.wrap(message.getMessageId().toByteArray()),
+                genericRecord.get(MetadataUtil.METADATA_MESSAGE_ID_KEY));
+        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_ORIGIN_PROPERTIES_KEY));
+        Map<Utf8, Utf8> utf8Utf8Map = (Map<Utf8, Utf8>) genericRecord.get(MetadataUtil.METADATA_ORIGIN_PROPERTIES_KEY);
+        Map<String, String> resultMap = utf8Utf8Map.entrySet().stream().collect(
+                Collectors.toMap(
+                        e -> e.getKey().toString(),
+                        e -> e.getValue().toString()
+                )
+        );
+        Assert.assertTrue(
+                mapsAreEqual(
+                        message.getReaderSchema().get().getSchemaInfo().getProperties(),
+                        resultMap
+                ));
+        Assert.assertNotNull(genericRecord.get(MetadataUtil.METADATA_ORIGIN_SCHEMA_VERSION_KEY));
+        Assert.assertEquals(ByteBuffer.wrap(message.getSchemaVersion()),
+                genericRecord.get(MetadataUtil.METADATA_ORIGIN_SCHEMA_VERSION_KEY));
+    }
+
+    public boolean mapsAreEqual(Map<String, String> mapA, Map<String, String> mapB) {
+
+        try {
+            for (String k : mapB.keySet()) {
+                if (!mapA.get(k).equals(mapB.get(k))) {
+                    return false;
+                }
+            }
+            for (String y : mapA.keySet()) {
+                if (!mapB.containsKey(y)) {
+                    return false;
+                }
+            }
+        } catch (NullPointerException np) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
@@ -32,8 +32,6 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.SinkRecord;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.jcloud.support.ParquetInputFile;
-import org.apache.pulsar.io.jcloud.util.AvroRecordUtil;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +55,13 @@ public class ParquetFormatTest extends FormatTestBase {
         return ".parquet";
     }
 
-    public void handleMessage(TopicName topicName, Message<GenericRecord> msg) {
+    @Override
+    protected boolean supportMetadata() {
+        return true;
+    }
+
+    public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
+                                                                          Message<GenericRecord> msg) throws Exception {
         @SuppressWarnings("unchecked")
         PulsarRecord<GenericRecord> test = PulsarRecord.<GenericRecord>builder()
                 .topicName(topicName.toString())
@@ -66,23 +70,19 @@ public class ParquetFormatTest extends FormatTestBase {
                 .build();
         List<Record<GenericRecord>> records = new ArrayList<>();
         records.add(new SinkRecord<>(test, test.getValue()));
-        try {
-            getFormat().initSchema(AvroRecordUtil.extractPulsarSchema(msg));
-            ByteSource byteSource = getFormat().recordWriter(records.listIterator());
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            stream.write(byteSource.read());
-            ParquetInputFile file = new ParquetInputFile("tmp.parquet", stream);
 
-            ParquetReader<org.apache.avro.generic.GenericRecord> reader = AvroParquetReader
-                    .<org.apache.avro.generic.GenericRecord>builder(file)
-                    .withDataModel(GenericData.get())
-                    .build();
-            org.apache.avro.generic.GenericRecord record = reader.read();
+        ByteSource byteSource = getFormat().recordWriter(records.listIterator());
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        stream.write(byteSource.read());
+        ParquetInputFile file = new ParquetInputFile("tmp.parquet", stream);
 
-            assertEquals(msg.getValue(), record);
-        } catch (Exception e) {
-            log.error("", e);
-            Assert.fail();
-        }
+        ParquetReader<org.apache.avro.generic.GenericRecord> reader = AvroParquetReader
+                .<org.apache.avro.generic.GenericRecord>builder(file)
+                .withDataModel(GenericData.get())
+                .build();
+        org.apache.avro.generic.GenericRecord record = reader.read();
+
+        return record;
+
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
@@ -71,7 +71,7 @@ public class ParquetFormatTest extends FormatTestBase {
             ByteSource byteSource = getFormat().recordWriter(records.listIterator());
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
             stream.write(byteSource.read());
-            ParquetInputFile file = new ParquetInputFile("a.parquet", stream);
+            ParquetInputFile file = new ParquetInputFile("tmp.parquet", stream);
 
             ParquetReader<org.apache.avro.generic.GenericRecord> reader = AvroParquetReader
                     .<org.apache.avro.generic.GenericRecord>builder(file)
@@ -80,8 +80,6 @@ public class ParquetFormatTest extends FormatTestBase {
             org.apache.avro.generic.GenericRecord record = reader.read();
 
             assertEquals(msg.getValue(), record);
-            System.out.println("build.record() = " + record);
-            System.out.println("record.getClass() = " + record.getClass());
         } catch (Exception e) {
             log.error("", e);
             Assert.fail();


### PR DESCRIPTION
fixed #31.
need add document.

Added `withMetadata` option to save metadata.
The default value of `withMetadata` is false.
When `withMetadata=true`, the format is json, avro, parquet, and metadata will be saved to the root of each piece of data.

## Example:

### When not using metadata, avro schema:
```json
{
  "type": "record",
  "name": "TestRecord",
  "namespace": "org.apache.pulsar.io.jcloud.bo",
  "fields": [
    {
      "name": "name",
      "type": [
        "null",
        "string"
      ],
      "default": null
    },
    {
      "name": "number",
      "type": "int"
    },
    {
      "name": "subRecord",
      "type": [
        "null",
        {
          "type": "record",
          "name": "TestSubRecord",
          "namespace": "org.apache.pulsar.io.jcloud.bo.TestRecord",
          "fields": [
            {
              "name": "name",
              "type": [
                "null",
                "string"
              ],
              "default": null
            }
          ]
        }
      ],
      "default": null
    }
  ]
}
```
Data: 
```json
{
  "name": "key1",
  "number": 1,
  "subRecord": null
}
```

### Using metadata, avro schema:
```json
{
  "type": "record",
  "name": "TestRecord",
  "namespace": "org.apache.pulsar.io.jcloud.bo",
  "fields": [
    {
      "name": "name",
      "type": [
        "null",
        "string"
      ],
      "default": null
    },
    {
      "name": "number",
      "type": "int"
    },
    {
      "name": "subRecord",
      "type": [
        "null",
        {
          "type": "record",
          "name": "TestSubRecord",
          "namespace": "org.apache.pulsar.io.jcloud.bo.TestRecord",
          "fields": [
            {
              "name": "name",
              "type": [
                "null",
                "string"
              ],
              "default": null
            }
          ]
        }
      ],
      "default": null
    },
    {
      "name": "__message_metadata__",
      "type": {
        "type": "record",
        "name": "MessageMetadata",
        "namespace": "",
        "fields": [
          {
            "name": "originProperties",
            "type": [
              "null",
              {
                "type": "map",
                "values": "string"
              }
            ]
          },
          {
            "name": "originSchemaVersion",
            "type": "bytes"
          },
          {
            "name": "messageId",
            "type": "bytes"
          }
        ]
      }
    }
  ]
}

```

Data:
```json
{
  "name": "key1",
  "number": 1,
  "subRecord": null,
  "__message_metadata__": {
    "originProperties": {
      "__alwaysAllowNull": "true",
      "__jsr310ConversionEnabled": "false"
    },
    "originSchemaVersion": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
    "messageId": "\b\u0002\u0010\u0000\u0018\u0000 \u00000\u0001"
  }
}
```