### PR TITLE
Add missing dependency for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <jclouds.version>2.3.0</jclouds.version>
     <parquet.version>1.11.1</parquet.version>
     <awsjavasdk.version>1.11.774</awsjavasdk.version>
+    <jaxb-api>2.3.1</jaxb-api>
 
     <!-- test dependencies -->
     <junit.version>4.13.1</junit.version>
@@ -347,6 +348,11 @@
     <dependency>
       <groupId>io.streamnative</groupId>
       <artifactId>pulsar-io-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb-api}</version>
     </dependency>
     <dependency>
       <groupId>io.streamnative</groupId>


### PR DESCRIPTION
*Motivation*

Pulsar 2.8 image is using Java 11. So we need to add additional dependencies to make sure it can be run on Pulsar 2.8 images.

