### PR TITLE
WIP: Use default credentials if specified.

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
@@ -84,8 +84,10 @@ public class CloudStorageGenericRecordSink extends BlobStoreAbstractSink<CloudSt
     public CloudStorageSinkConfig loadConfig(Map<String, Object> config, SinkContext sinkContext) throws IOException {
 
         CloudStorageSinkConfig sinkConfig = CloudStorageSinkConfig.load(config);
-        checkNotNull(sinkConfig.getAccessKeyId(), "accessKeyId property not set.");
-        checkNotNull(sinkConfig.getSecretAccessKey(), "secretAccessKey property not set.");
+        if (!sinkConfig.isUseDefaultCredentials()) {
+            checkNotNull(sinkConfig.getAccessKeyId(), "accessKeyId property not set.");
+            checkNotNull(sinkConfig.getSecretAccessKey(), "secretAccessKey property not set.");
+        }
         return sinkConfig;
     }
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkConfig.java
@@ -47,6 +47,12 @@ public class CloudStorageSinkConfig extends BlobStoreAbstractConfig {
 
     private String roleSessionName;
 
+    /**
+     * If specified, indicates to use the default credentials form the underlying node,
+     * rather than using the specified key and secret.
+     */
+    private boolean useDefaultCredentials = false;
+
     public static CloudStorageSinkConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), CloudStorageSinkConfig.class);
@@ -60,7 +66,9 @@ public class CloudStorageSinkConfig extends BlobStoreAbstractConfig {
     @Override
     public void validate() {
         super.validate();
-        checkNotNull(accessKeyId, "accessKeyId property not set.");
-        checkNotNull(secretAccessKey, "secretAccessKey property not set.");
+        if (!useDefaultCredentials) {
+            checkNotNull(accessKeyId, "accessKeyId property not set.");
+            checkNotNull(secretAccessKey, "secretAccessKey property not set.");
+        }
     }
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/CredentialsUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/CredentialsUtil.java
@@ -35,8 +35,10 @@ public class CredentialsUtil {
      * @return aws credential provider
      */
     public static AWSCredentialsProvider getAWSCredentialProvider(CloudStorageSinkConfig config) {
-        System.setProperty("aws.accessKeyId", config.getAccessKeyId());
-        System.setProperty("aws.secretKey", config.getSecretAccessKey());
+        if (!config.isUseDefaultCredentials()) {
+            System.setProperty("aws.accessKeyId", config.getAccessKeyId());
+            System.setProperty("aws.secretKey", config.getSecretAccessKey());
+        }
         if (Strings.isNullOrEmpty(config.getRole())) {
             return DefaultAWSCredentialsProviderChain.getInstance();
         } else {


### PR DESCRIPTION
In AWS, we don't *require* an AWS access key or secret, the reason is
that we can use the "native" credentials from the provider chain.

This change indicates to use the default provider chain instead of using
values in the properties

This still needs tests, but it is high priority to allow for some more
flexibility for deploying this in environments where we cannot use an
AWS key and secret

