### PR TITLE
remove `pulsar-functions-instance` dep from tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,21 +385,13 @@
     </dependency>
     <dependency>
       <groupId>io.streamnative</groupId>
-      <artifactId>pulsar-functions-instance</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.streamnative</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <version>${pulsar.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.streamnative</groupId>
       <artifactId>pulsar-client-admin-original</artifactId>
       <version>${pulsar.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
@@ -38,9 +38,9 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.io.jcloud.container.PulsarContainer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
@@ -73,7 +73,7 @@ public abstract class PulsarTestBase {
         log.info("-------------------------------------------------------------------------");
 
 
-        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "apachepulsar/pulsar:2.7.0");
+        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "streamnative/pulsar:2.8.0.7");
         pulsarService = new PulsarContainer(DockerImageName.parse(pulsarImage));
         pulsarService.waitingFor(new HttpWaitStrategy()
                 .forPort(BROKER_HTTP_PORT)

--- a/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.container;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * PulsarContainer uses streamnative images.
+ */
+public class PulsarContainer extends GenericContainer<PulsarContainer> {
+
+    public static final int BROKER_PORT = 6650;
+    public static final int BROKER_HTTP_PORT = 8080;
+    public static final String METRICS_ENDPOINT = "/metrics";
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("streamnative/pulsar");
+    @Deprecated
+    private static final String DEFAULT_TAG = "2.8.0.7";
+
+    private boolean functionsWorkerEnabled = false;
+
+    /**
+     * @deprecated use {@link PulsarContainer(DockerImageName)} instead
+     */
+    @Deprecated
+    public PulsarContainer() {
+        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+    }
+
+    /**
+     * @deprecated use {@link PulsarContainer(DockerImageName)} instead
+     */
+    @Deprecated
+    public PulsarContainer(String pulsarVersion) {
+        this(DEFAULT_IMAGE_NAME.withTag(pulsarVersion));
+    }
+
+    public PulsarContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DockerImageName.parse("streamnative/pulsar"));
+
+        withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
+        withCommand("/pulsar/bin/pulsar", "standalone", "--no-functions-worker", "-nss");
+        waitingFor(Wait.forHttp(METRICS_ENDPOINT).forStatusCode(200).forPort(BROKER_HTTP_PORT));
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+
+        if (functionsWorkerEnabled) {
+            withCommand("/pulsar/bin/pulsar", "standalone");
+            waitingFor(
+                    new WaitAllStrategy()
+                            .withStrategy(waitStrategy)
+                            .withStrategy(Wait.forLogMessage(".*Function worker service started.*", 1))
+            );
+        }
+    }
+
+    public PulsarContainer withFunctionsWorker() {
+        functionsWorkerEnabled = true;
+        return this;
+    }
+
+    public String getPulsarBrokerUrl() {
+        return String.format("pulsar://%s:%s", getHost(), getMappedPort(BROKER_PORT));
+    }
+
+    public String getHttpServiceUrl() {
+        return String.format("http://%s:%s", getHost(), getMappedPort(BROKER_HTTP_PORT));
+    }
+}

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.io.jcloud.format;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import com.google.common.io.ByteSource;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -35,8 +37,6 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.apache.pulsar.functions.instance.SinkRecord;
-import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.jcloud.util.AvroRecordUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -68,14 +68,18 @@ public class BytesFormatTest extends FormatTestBase {
 
     public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
                                                                           Message<GenericRecord> msg) throws Exception {
-        @SuppressWarnings("unchecked")
-        PulsarRecord<GenericRecord> test = PulsarRecord.<GenericRecord>builder()
-                .topicName(topicName.toString())
-                .partition(0)
-                .message(msg)
-                .build();
+        Record<GenericRecord> mockRecord = mock(Record.class);
+        Schema<GenericRecord> mockSchema = mock(Schema.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
+        when(mockRecord.getValue()).thenReturn(msg.getValue());
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        when(mockRecord.getSchema()).thenReturn(mockSchema);
+
         List<Record<GenericRecord>> records = new ArrayList<>();
-        records.add(new SinkRecord<>(test, test.getValue()));
+        records.add(mockRecord);
 
         ByteSource byteSource = getFormat().recordWriter(records.listIterator());
         final byte[] expecteds =
@@ -85,7 +89,7 @@ public class BytesFormatTest extends FormatTestBase {
             return null;
         }
         return AvroRecordUtil.convertGenericRecord(
-                test.getValue(),
+                mockRecord.getValue(),
                 AvroRecordUtil.convertToAvroSchema(msg.getReaderSchema().get()));
     }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
@@ -18,19 +18,21 @@
  */
 package org.apache.pulsar.io.jcloud.format;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import com.google.common.io.ByteSource;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.avro.generic.GenericData;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
-import org.apache.pulsar.functions.instance.SinkRecord;
-import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.jcloud.support.ParquetInputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,14 +64,19 @@ public class ParquetFormatTest extends FormatTestBase {
 
     public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
                                                                           Message<GenericRecord> msg) throws Exception {
-        @SuppressWarnings("unchecked")
-        PulsarRecord<GenericRecord> test = PulsarRecord.<GenericRecord>builder()
-                .topicName(topicName.toString())
-                .partition(0)
-                .message(msg)
-                .build();
+
+        Record<GenericRecord> mockRecord = mock(Record.class);
+        Schema<GenericRecord> mockSchema = mock(Schema.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        when(mockRecord.getSchema()).thenReturn(mockSchema);
+        when(mockRecord.getValue()).thenReturn(msg.getValue());
+
         List<Record<GenericRecord>> records = new ArrayList<>();
-        records.add(new SinkRecord<>(test, test.getValue()));
+        records.add(mockRecord);
 
         ByteSource byteSource = getFormat().recordWriter(records.listIterator());
         ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -22,11 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.google.common.base.Supplier;
 import java.text.MessageFormat;
+import java.util.Optional;
 import junit.framework.TestCase;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class PartitionerTest extends TestCase {
     public String expectedPartitionedPath;
 
     @Parameterized.Parameter(3)
-    public PulsarRecord<Object> pulsarRecord;
+    public Record<Object> pulsarRecord;
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -107,30 +108,34 @@ public class PartitionerTest extends TestCase {
         };
     }
 
-    public static PulsarRecord<Object> getPartitionedTopic() {
+    public static Record<Object> getPartitionedTopic() {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
         when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
         String topic = TopicName.get("test-partition-1").toString();
-        return PulsarRecord.<Object>builder()
-                .message(mock)
-                .topicName(topic)
-                .partition(1)
-                .build();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
     }
 
-    public static PulsarRecord<Object> getTopic() {
+    public static Record<Object> getTopic() {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
         when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
         String topic = TopicName.get("test").toString();
-        return PulsarRecord.<Object>builder()
-                .message(mock)
-                .topicName(topic)
-                .partition(1)
-                .build();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
     }
 
     @Test

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
@@ -22,11 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.google.common.base.Supplier;
 import java.text.MessageFormat;
+import java.util.Optional;
 import junit.framework.TestCase;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
     public String expectedPartitionedPath;
 
     @Parameterized.Parameter(3)
-    public PulsarRecord<Object> pulsarRecord;
+    public Record<Object> pulsarRecord;
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -109,30 +110,34 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
         };
     }
 
-    public static PulsarRecord<Object> getPartitionedTopic() {
+    public static Record<byte[]> getPartitionedTopic() {
         @SuppressWarnings("unchecked")
-        Message<Object> mock = mock(Message.class);
+        Message<byte[]> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
         when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
         String topic = TopicName.get("test-partition-1").toString();
-        return PulsarRecord.<Object>builder()
-                .message(mock)
-                .topicName(topic)
-                .partition(1)
-                .build();
+        Record<byte[]> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
     }
 
-    public static PulsarRecord<Object> getTopic() {
+    public static Record<Object> getTopic() {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
         when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
         String topic = TopicName.get("test").toString();
-        return PulsarRecord.<Object>builder()
-                .message(mock)
-                .topicName(topic)
-                .partition(1)
-                .build();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
     }
 
     @Test


### PR DESCRIPTION
tests are using `pulsar-functions-instance` and it will pollute the dep tree of pulsar io connector. 
this PR removes the dep and use mock to run tests.