### PR TITLE
align `partitionerType` options

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -37,10 +37,7 @@ import org.apache.pulsar.io.jcloud.format.BytesFormat;
 import org.apache.pulsar.io.jcloud.format.Format;
 import org.apache.pulsar.io.jcloud.format.JsonFormat;
 import org.apache.pulsar.io.jcloud.format.ParquetFormat;
-import org.apache.pulsar.io.jcloud.partitioner.Partitioner;
 import org.apache.pulsar.io.jcloud.partitioner.PartitionerType;
-import org.apache.pulsar.io.jcloud.partitioner.SimplePartitioner;
-import org.apache.pulsar.io.jcloud.partitioner.TimePartitioner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -114,7 +114,7 @@ public class BlobStoreAbstractConfig implements Serializable {
         }
 
         if (!partitionerMap.containsKey(StringUtils.lowerCase(partitionerType))
-                || partitionerType.equalsIgnoreCase("default")) {
+                && !partitionerType.equalsIgnoreCase("default")) {
             throw new IllegalArgumentException("partitionerType property not set.");
         }
         if (PartitionerType.time.name().equalsIgnoreCase(partitionerType)) {

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.io.jcloud.format.Format;
 import org.apache.pulsar.io.jcloud.format.JsonFormat;
 import org.apache.pulsar.io.jcloud.format.ParquetFormat;
 import org.apache.pulsar.io.jcloud.partitioner.Partitioner;
+import org.apache.pulsar.io.jcloud.partitioner.PartitionerType;
 import org.apache.pulsar.io.jcloud.partitioner.SimplePartitioner;
 import org.apache.pulsar.io.jcloud.partitioner.TimePartitioner;
 import org.slf4j.Logger;
@@ -61,8 +62,8 @@ public class BlobStoreAbstractConfig implements Serializable {
             .put("bytes", new BytesFormat())
             .build();
     private static final Map<String, Partitioner<?>> partitionerMap = new ImmutableMap.Builder<String, Partitioner<?>>()
-            .put("default", new SimplePartitioner<>())
-            .put("time", new TimePartitioner<>())
+            .put(PartitionerType.DEFAULT.name, new SimplePartitioner<>())
+            .put(PartitionerType.TIME.name, new TimePartitioner<>())
             .build();
 
     public static final String PROVIDER_AWSS3 = "aws-s3";
@@ -115,7 +116,7 @@ public class BlobStoreAbstractConfig implements Serializable {
         if (!partitionerMap.containsKey(StringUtils.lowerCase(partitionerType))) {
             throw new IllegalArgumentException("partitionerType property not set.");
         }
-        if ("time".equalsIgnoreCase(partitionerType)) {
+        if (PartitionerType.TIME.name.equalsIgnoreCase(partitionerType)) {
             if (StringUtils.isNoneBlank(timePartitionPattern)) {
                 LOGGER.info("test timePartitionPattern is ok {} {}",
                         timePartitionPattern,

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -63,7 +63,6 @@ public class BlobStoreAbstractConfig implements Serializable {
             .build();
     private static final Map<String, Partitioner<?>> partitionerMap = new ImmutableMap.Builder<String, Partitioner<?>>()
             .put(PartitionerType.partition.name(), new SimplePartitioner<>())
-            .put("partition", new SimplePartitioner<>())
             .put(PartitionerType.time.name(), new TimePartitioner<>())
             .build();
 
@@ -114,7 +113,8 @@ public class BlobStoreAbstractConfig implements Serializable {
             throw new IllegalArgumentException("formatType property not set.");
         }
 
-        if (!partitionerMap.containsKey(StringUtils.lowerCase(partitionerType))) {
+        if (!partitionerMap.containsKey(StringUtils.lowerCase(partitionerType))
+                || partitionerType.equalsIgnoreCase("default")) {
             throw new IllegalArgumentException("partitionerType property not set.");
         }
         if (PartitionerType.time.name().equalsIgnoreCase(partitionerType)) {

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -62,8 +62,8 @@ public class BlobStoreAbstractConfig implements Serializable {
             .put("bytes", new BytesFormat())
             .build();
     private static final Map<String, Partitioner<?>> partitionerMap = new ImmutableMap.Builder<String, Partitioner<?>>()
-            .put(PartitionerType.PARTITION.name, new SimplePartitioner<>())
-            .put(PartitionerType.TIME.name, new TimePartitioner<>())
+            .put(PartitionerType.partition.name(), new SimplePartitioner<>())
+            .put(PartitionerType.time.name(), new TimePartitioner<>())
             .build();
 
     public static final String PROVIDER_AWSS3 = "aws-s3";
@@ -116,7 +116,7 @@ public class BlobStoreAbstractConfig implements Serializable {
         if (!partitionerMap.containsKey(StringUtils.lowerCase(partitionerType))) {
             throw new IllegalArgumentException("partitionerType property not set.");
         }
-        if (PartitionerType.TIME.name.equalsIgnoreCase(partitionerType)) {
+        if (PartitionerType.time.name().equalsIgnoreCase(partitionerType)) {
             if (StringUtils.isNoneBlank(timePartitionPattern)) {
                 LOGGER.info("test timePartitionPattern is ok {} {}",
                         timePartitionPattern,

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -63,6 +63,7 @@ public class BlobStoreAbstractConfig implements Serializable {
             .build();
     private static final Map<String, Partitioner<?>> partitionerMap = new ImmutableMap.Builder<String, Partitioner<?>>()
             .put(PartitionerType.partition.name(), new SimplePartitioner<>())
+            .put("partition", new SimplePartitioner<>())
             .put(PartitionerType.time.name(), new TimePartitioner<>())
             .build();
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -62,7 +62,7 @@ public class BlobStoreAbstractConfig implements Serializable {
             .put("bytes", new BytesFormat())
             .build();
     private static final Map<String, Partitioner<?>> partitionerMap = new ImmutableMap.Builder<String, Partitioner<?>>()
-            .put(PartitionerType.DEFAULT.name, new SimplePartitioner<>())
+            .put(PartitionerType.PARTITION.name, new SimplePartitioner<>())
             .put(PartitionerType.TIME.name, new TimePartitioner<>())
             .build();
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
@@ -22,11 +22,6 @@ package org.apache.pulsar.io.jcloud.partitioner;
  * partitioner types.
  */
 public enum PartitionerType {
-    PARTITION("partition"),
-    TIME("time");
-    public final String name;
-
-    PartitionerType(String name) {
-        this.name = name;
-    }
+    partition,
+    time;
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
@@ -22,6 +22,6 @@ package org.apache.pulsar.io.jcloud.partitioner;
  * partitioner types.
  */
 public enum PartitionerType {
-    partition,
-    time;
+    PARTITION,
+    TIME;
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
@@ -22,7 +22,7 @@ package org.apache.pulsar.io.jcloud.partitioner;
  * partitioner types.
  */
 public enum PartitionerType {
-    DEFAULT("partition"),
+    PARTITION("partition"),
     TIME("time");
     public final String name;
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.partitioner;
+
+/**
+ * partitioner types.
+ */
+public enum PartitionerType {
+    DEFAULT("partition"),
+    TIME("time");
+    public final String name;
+
+    PartitionerType(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -124,7 +124,7 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), "partition"));
+        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.PARTITION.name));
         switch (partitionerType) {
             case TIME:
                 partitioner = new TimePartitioner<>();

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -129,7 +129,7 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
             case TIME:
                 partitioner = new TimePartitioner<>();
                 break;
-            case DEFAULT:
+            case PARTITION:
                 partitioner = new SimplePartitioner<>();
                 break;
             default:

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -124,19 +125,14 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        String partitionerTypeName = StringUtils.defaultIfBlank(
-                sinkConfig.getPartitionerType(), PartitionerType.partition.name());
-        PartitionerType partitionerType;
-        try {
-            partitionerType = PartitionerType.valueOf(partitionerTypeName);
-        } catch (Exception e) {
-            throw new RuntimeException("not support partitioner type " + partitionerTypeName);
-        }
+        String partitionerTypeName = sinkConfig.getPartitionerType();
+        PartitionerType partitionerType =
+                EnumUtils.getEnumIgnoreCase(PartitionerType.class, partitionerTypeName, PartitionerType.PARTITION);
         switch (partitionerType) {
-            case time:
+            case TIME:
                 partitioner = new TimePartitioner<>();
                 break;
-            case partition:
+            case PARTITION:
             default:
                 partitioner = new SimplePartitioner<>();
                 break;

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -124,12 +124,12 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.PARTITION.name));
+        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.partition.name()));
         switch (partitionerType) {
-            case TIME:
+            case time:
                 partitioner = new TimePartitioner<>();
                 break;
-            case PARTITION:
+            case partition:
                 partitioner = new SimplePartitioner<>();
                 break;
             default:

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.io.jcloud.format.InitConfiguration;
 import org.apache.pulsar.io.jcloud.format.JsonFormat;
 import org.apache.pulsar.io.jcloud.format.ParquetFormat;
 import org.apache.pulsar.io.jcloud.partitioner.Partitioner;
+import org.apache.pulsar.io.jcloud.partitioner.PartitionerType;
 import org.apache.pulsar.io.jcloud.partitioner.SimplePartitioner;
 import org.apache.pulsar.io.jcloud.partitioner.TimePartitioner;
 import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
@@ -123,12 +124,12 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        String partitionerType = StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), "partition");
+        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), "partition"));
         switch (partitionerType) {
-            case "time":
+            case TIME:
                 partitioner = new TimePartitioner<>();
                 break;
-            case "partition":
+            case DEFAULT:
                 partitioner = new SimplePartitioner<>();
                 break;
             default:

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -124,7 +124,9 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        PartitionerType partitionerType = PartitionerType.valueOf(StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.partition.name()));
+        PartitionerType partitionerType =
+                PartitionerType.valueOf(
+                        StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.partition.name()));
         switch (partitionerType) {
             case time:
                 partitioner = new TimePartitioner<>();

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -124,18 +124,22 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private Partitioner<GenericRecord> buildPartitioner(V sinkConfig) {
         Partitioner<GenericRecord> partitioner;
-        PartitionerType partitionerType =
-                PartitionerType.valueOf(
-                        StringUtils.defaultIfBlank(sinkConfig.getPartitionerType(), PartitionerType.partition.name()));
+        String partitionerTypeName = StringUtils.defaultIfBlank(
+                sinkConfig.getPartitionerType(), PartitionerType.partition.name());
+        PartitionerType partitionerType;
+        try {
+            partitionerType = PartitionerType.valueOf(partitionerTypeName);
+        } catch (Exception e) {
+            throw new RuntimeException("not support partitioner type " + partitionerTypeName);
+        }
         switch (partitionerType) {
             case time:
                 partitioner = new TimePartitioner<>();
                 break;
             case partition:
+            default:
                 partitioner = new SimplePartitioner<>();
                 break;
-            default:
-                throw new RuntimeException("not support partitioner type " + partitionerType);
         }
         partitioner.configure(sinkConfig);
         return partitioner;

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.jcloud.partitioner;
 
 import static org.junit.Assert.assertEquals;
+import org.apache.commons.lang3.EnumUtils;
 import org.junit.Test;
 
 /**
@@ -27,7 +28,7 @@ import org.junit.Test;
 public class PartitionerTypeTest {
     @Test
     public void testValueOf() {
-        assertEquals(PartitionerType.partition, PartitionerType.valueOf("partition"));
-        assertEquals(PartitionerType.time, PartitionerType.valueOf("time"));
+        assertEquals(PartitionerType.PARTITION, EnumUtils.getEnumIgnoreCase(PartitionerType.class, "partition"));
+        assertEquals(PartitionerType.TIME, EnumUtils.getEnumIgnoreCase(PartitionerType.class, "time"));
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.partitioner;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * partitionerType unit test.
+ */
+public class PartitionerTypeTest {
+    @Test
+    public void testValueOf() {
+        assertEquals(PartitionerType.partition, PartitionerType.valueOf("partition"));
+        assertEquals(PartitionerType.time, PartitionerType.valueOf("time"));
+    }
+}


### PR DESCRIPTION
Currently, cloud-storage connector supports `partition` and `time` partitioner, but the code uses `default` and `partition` to indicate `partition`, and makes the `partition` type not work as expected.
This PR fixes the issue, and makes `partition` as the default partitioner