### PR TITLE
fix gcs credential

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/credential/GcsCredential.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/credential/GcsCredential.java
@@ -53,7 +53,7 @@ public class GcsCredential implements JcloudsCredential {
             return () -> new GoogleCredentialsFromJson(gcsKeyContent).get();
         } else if (StringUtils.isNotEmpty(gcsKeyPath)) {
             try {
-                loadFromFile(gcsKeyPath);
+                return loadFromFile(gcsKeyPath);
             } catch (Exception ex) {
                 LOGGER.error("Cannot read GCS service account credentials file: {}", gcsKeyPath);
                 throw new IllegalArgumentException(ex);
@@ -62,7 +62,7 @@ public class GcsCredential implements JcloudsCredential {
             final String envFilePath = System.getProperty(GOOGLE_APPLICATION_CREDENTIALS_ENV);
             if (StringUtils.isNotEmpty(envFilePath)) {
                 try {
-                    loadFromFile(envFilePath);
+                    return loadFromFile(envFilePath);
                 } catch (Exception ex) {
                     LOGGER.error("Cannot read GCS service account credentials file: {}", envFilePath);
                     throw new IllegalArgumentException(ex);


### PR DESCRIPTION
`RuntimeSpawner quit because of
java.lang.IllegalArgumentException: The service account key path and key content is empty for GCS driver` when with `gcsServiceAccountKeyFilePath` given. 