### PR TITLE
support more scales to time partitioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Cloud Storage sink connector supports the following properties.
 | `formatType` | String| False | "json" | The data format type. Available options are JSON, Avro, Bytes, or Parquet. By default, it is set to JSON. |
 | `partitionerType` | String| False |"partition" | The partitioning type. It can be configured by topic partitions or by time. By default, the partition type is configured by topic partitions. |
 | `timePartitionPattern` | String| False |"yyyy-MM-dd" | The format pattern of the time-based partitioning. For details, refer to the Java date and time format. |
-| `timePartitionDuration` | String| False |"1d" | The time interval for time-based partitioning, such as 1d, or 1h. |
+| `timePartitionDuration` | String| False |"86400000" | The time interval for time-based partitioning, support formatted interval string, such as `30d`, `24h`, `30m`, `10s`, also support number in milliseconds precision, such as `86400000` refers to `24h` or `1d`. |
 | `batchSize` | int | False |10 | The number of records submitted in batch. |
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
 | `sliceTopicPartitionPath` | Boolean| False |false | When it is set to `true`, split the partitioned topic name into separate folders in the bucket path. |

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -64,7 +64,7 @@ The Cloud Storage sink connector supports the following properties.
 | `formatType` | String| False | "json" | The data format type: JSON, Avro, or Parquet. By default, it is set to JSON. |
 | `partitionerType` | String| False |"partition" | The partition type. It can be configured by partition or time. By default, the partition type is configured by partition. |
 | `timePartitionPattern` | String| False |"yyyy-MM-dd" | The format pattern of the time partition. For details, refer to the Java date and time format. |
-| `timePartitionDuration` | String| False |"1d" | The time interval divided by time, such as 1d, or 1h. |
+| `timePartitionDuration` | String| False |"86400000" | The time interval for time-based partitioning, support formatted interval string, such as `30d`, `24h`, `30m`, `10s`, also support number in milliseconds precision, such as `86400000` refers to `24h` or `1d`. |
 | `batchSize` | int | False |10 | The number of records submitted in batch. |
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
 | `sliceTopicPartitionPath` | Boolean | False |1000 |  When it is set to `true`, split the partitioned topic name into separate folders in the bucket path. |

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/TimePartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/TimePartitioner.java
@@ -59,16 +59,28 @@ public class TimePartitioner<T> extends AbstractPartitioner<T> {
         if (StringUtils.isBlank(timePartitionDuration)) {
             return DEFAULT_PARTITION_DURATION;
         }
-        String number = timePartitionDuration.substring(0, timePartitionDuration.length() - 1);
-        switch (timePartitionDuration.charAt(timePartitionDuration.length() - 1)) {
-            case 'd':
-            case 'D':
-                return Long.parseLong(number) * 24L * 3600L * 1000L;
-            case 'h':
-            case 'H':
-                return Long.parseLong(number) * 3600L * 1000L;
-            default:
-                throw new RuntimeException("not support timePartitionPattern " + timePartitionDuration);
+        if (Character.isAlphabetic(timePartitionDuration.charAt(timePartitionDuration.length() - 1))) {
+            String number = timePartitionDuration.substring(0, timePartitionDuration.length() - 1);
+            switch (timePartitionDuration.charAt(timePartitionDuration.length() - 1)) {
+                case 'd':
+                case 'D':
+                    return Long.parseLong(number) * 24L * 3600L * 1000L;
+                case 'h':
+                case 'H':
+                    return Long.parseLong(number) * 3600L * 1000L;
+                case 'm':
+                    return Long.parseLong(number) * 60L * 1000L;
+                case 's':
+                    return Long.parseLong(number) * 1000L;
+                default:
+                    throw new RuntimeException("not supported time duration scale " + timePartitionDuration);
+            }
+        } else {
+            try {
+                return Long.parseLong(timePartitionDuration);
+            } catch (NumberFormatException ex) {
+                throw new RuntimeException("not supported time duration format " + timePartitionDuration, ex);
+            }
         }
     }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -75,6 +75,12 @@ public class PartitionerTest extends TestCase {
         noPartitionNumberblobStoreAbstractConfig.setWithTopicPartitionNumber(false);
         SimplePartitioner<Object> noPartitionNumberPartitioner = new SimplePartitioner<>();
         noPartitionNumberPartitioner.configure(noPartitionNumberblobStoreAbstractConfig);
+
+        BlobStoreAbstractConfig numberConfig = new BlobStoreAbstractConfig();
+        numberConfig.setTimePartitionDuration("7200000");
+        numberConfig.setTimePartitionPattern("yyyy-MM-dd-HH");
+        TimePartitioner<Object> numberPartitioner = new TimePartitioner<>();
+        numberPartitioner.configure(numberConfig);
         return new Object[][]{
                 new Object[]{
                         simplePartitioner,
@@ -117,7 +123,13 @@ public class PartitionerTest extends TestCase {
                         "3221225506",
                         "public/default/test" + Partitioner.PATH_SEPARATOR + "3221225506",
                         getPartitionedTopic()
-                }
+                },
+                new Object[]{
+                        numberConfig,
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
         };
     }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -125,7 +125,7 @@ public class PartitionerTest extends TestCase {
                         getPartitionedTopic()
                 },
                 new Object[]{
-                        numberConfig,
+                        numberPartitioner,
                         "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
                         "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
                         getPartitionedTopic()

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -126,8 +126,8 @@ public class PartitionerTest extends TestCase {
                 },
                 new Object[]{
                         numberPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08-14" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "public/default/test-partition-1/2020-09-08-14" + Partitioner.PATH_SEPARATOR + "3221225506",
                         getPartitionedTopic()
                 },
         };


### PR DESCRIPTION
Currently the time partitioner only support formatted interval string like `1d` or `10h`, and not support more precise scales like minutes and seconds, or even milliseconds. This PR allows user to use `m` and `s`, also allows user use milliseconds string directly to time partitioner.