### PR TITLE
support `humanReadableMessageId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The Cloud Storage sink connector supports the following properties.
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
 | `sliceTopicPartitionPath` | Boolean| False |false | When it is set to `true`, split the partitioned topic name into separate folders in the bucket path. |
 | `withMetadata` | Boolean | False |false | Save message attributes to metadata. |
+| `useHumanReadableMessageId` | Boolean | False |false | Use human-readable format string for messageId in message metadata, the messageId will be in format like `ledgerId:entryId:partitionIndex:batchIndex`. Otherwise, the messageId will be in Hex-encoded string.|
 | `withTopicPartitionNumber` | Boolean | False |true | When it is set to `true`, include topic partition number to the object path. |
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -69,6 +69,7 @@ The Cloud Storage sink connector supports the following properties.
 | `batchTimeMs` | long | False |1000 | The interval for batch submission. |
 | `sliceTopicPartitionPath` | Boolean | False |1000 |  When it is set to `true`, split the partitioned topic name into separate folders in the bucket path. |
 | `withMetadata` | Boolean | False |false | Save message attributes to metadata. |
+| `useHumanReadableMessageId` | Boolean | False |false | Use human-readable format string for messageId in message metadata, the messageId will be in format like `ledgerId:entryId:partitionIndex:batchIndex`. Otherwise, the messageId will be in Hex-encoded string.|
 | `withTopicPartitionNumber` | Boolean | False |true | When it is set to `true`, include topic partition number to the object path. |
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -92,6 +92,7 @@ public class BlobStoreAbstractConfig implements Serializable {
     private long batchTimeMs = 1000;
 
     private boolean withMetadata;
+    private boolean useHumanReadableMessageId = false;
     private boolean withTopicPartitionNumber = true;
     private String bytesFormatTypeSeparator = "0x10";
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -77,7 +77,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     public void initSchema(org.apache.pulsar.client.api.Schema<GenericRecord> schema) {
         rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         if (useMetadata){
-            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema);
+            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema, useHumanReadableMessageId);
         }
     }
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -57,7 +57,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
-        this.useHumanReadableMessageId = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
         String codecName = configuration.getAvroCodec();
         if (codecName == null) {
             this.codecFactory = CodecFactory.nullCodec();

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -92,7 +92,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
 
                 if (useMetadata) {
-                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
+                    org.apache.avro.generic.GenericRecord metadataRecord =
+                            MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 fileWriter.append(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -46,6 +46,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
+    private boolean useHumanReadableMessageId;
     private CodecFactory codecFactory;
 
     @Override
@@ -56,6 +57,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isWithMetadata();
         String codecName = configuration.getAvroCodec();
         if (codecName == null) {
             this.codecFactory = CodecFactory.nullCodec();
@@ -90,7 +92,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
 
                 if (useMetadata) {
-                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next);
+                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 fileWriter.append(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -45,6 +45,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private ObjectMapper objectMapper;
 
     private boolean useMetadata;
+    private boolean useHumanReadableMessageId;
 
     @Override
     public String getExtension() {
@@ -54,6 +55,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isWithMetadata();
     }
 
     @Override
@@ -70,7 +72,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             log.debug("next record {} schema {} val {}", next, next.getSchema(), val);
             Map<String, Object> writeValue = convertRecordToObject(next.getValue());
             if (useMetadata) {
-                writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY, MetadataUtil.extractedMetadata(next));
+                writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY, MetadataUtil.extractedMetadata(next, useHumanReadableMessageId));
             }
             String recordAsString = objectMapper.writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -55,7 +55,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
-        this.useHumanReadableMessageId = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -72,7 +72,8 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             log.debug("next record {} schema {} val {}", next, next.getSchema(), val);
             Map<String, Object> writeValue = convertRecordToObject(next.getValue());
             if (useMetadata) {
-                writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY, MetadataUtil.extractedMetadata(next, useHumanReadableMessageId));
+                writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY,
+                        MetadataUtil.extractedMetadata(next, useHumanReadableMessageId));
             }
             String recordAsString = objectMapper.writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -85,7 +85,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                 org.apache.avro.generic.GenericRecord writeRecord = AvroRecordUtil
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
                 if (useMetadata) {
-                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
+                    org.apache.avro.generic.GenericRecord metadataRecord =
+                            MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 parquetWriter.write(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -62,7 +62,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     public void initSchema(org.apache.pulsar.client.api.Schema<GenericRecord> schema) {
         rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         if (useMetadata){
-            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema);
+            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema, useHumanReadableMessageId);
         }
     }
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -50,10 +50,12 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
+    private boolean useHumanReadableMessageId;
 
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isWithMetadata();
     }
 
     @Override
@@ -83,7 +85,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                 org.apache.avro.generic.GenericRecord writeRecord = AvroRecordUtil
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
                 if (useMetadata) {
-                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next);
+                    org.apache.avro.generic.GenericRecord metadataRecord = MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 parquetWriter.write(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -55,7 +55,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
-        this.useHumanReadableMessageId = configuration.isWithMetadata();
+        this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -42,15 +42,15 @@ import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
  * parquet format.
  */
 public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<BlobStoreAbstractConfig> {
-    @Override
-    public String getExtension() {
-        return ".parquet";
-    }
-
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
+
+    @Override
+    public String getExtension() {
+        return ".parquet";
+    }
 
     @Override
     public void configure(BlobStoreAbstractConfig configuration) {

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -44,7 +44,8 @@ public class MetadataUtil {
 
     private static ThreadLocal<List<Schema.Field>> schemaFieldThreadLocal = ThreadLocal.withInitial(ArrayList::new);
 
-    public static org.apache.avro.generic.GenericRecord extractedMetadataRecord(Record<GenericRecord> next, boolean useHumanReadableMessageId) {
+    public static org.apache.avro.generic.GenericRecord extractedMetadataRecord(Record<GenericRecord> next,
+                                                                                boolean useHumanReadableMessageId) {
         final Message<GenericRecord> message = next.getMessage().get();
 
         GenericData.Record record = new GenericData.Record(MESSAGE_METADATA);
@@ -67,7 +68,8 @@ public class MetadataUtil {
         return extractedMetadata(next, false);
     }
 
-    public static Map<String, Object> extractedMetadata(Record<GenericRecord> next, boolean useHumanReadableMessageId) {
+    public static Map<String, Object> extractedMetadata(Record<GenericRecord> next,
+                                                        boolean useHumanReadableMessageId) {
         Map<String, Object> metadata = new HashMap<>();
         final Message<GenericRecord> message = next.getMessage().get();
         metadata.put(METADATA_PROPERTIES_KEY, message.getProperties());

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -52,8 +52,7 @@ public class MetadataUtil {
         record.put(METADATA_PROPERTIES_KEY, message.getProperties());
         record.put(METADATA_SCHEMA_VERSION_KEY, ByteBuffer.wrap(message.getSchemaVersion()));
         if (useHumanReadableMessageId) {
-            record.put(METADATA_MESSAGE_ID_KEY, ByteBuffer.wrap(message.getMessageId().toString().getBytes(
-                    StandardCharsets.UTF_8)));
+            record.put(METADATA_MESSAGE_ID_KEY, message.getMessageId().toString().getBytes(StandardCharsets.UTF_8));
         } else {
             record.put(METADATA_MESSAGE_ID_KEY, ByteBuffer.wrap(message.getMessageId().toByteArray()));
         }
@@ -75,8 +74,7 @@ public class MetadataUtil {
         metadata.put(METADATA_PROPERTIES_KEY, message.getProperties());
         metadata.put(METADATA_SCHEMA_VERSION_KEY, message.getSchemaVersion());
         if (useHumanReadableMessageId) {
-            metadata.put(METADATA_MESSAGE_ID_KEY, ByteBuffer.wrap(message.getMessageId().toString()
-                            .getBytes(StandardCharsets.UTF_8)));
+            metadata.put(METADATA_MESSAGE_ID_KEY, message.getMessageId().toString().getBytes(StandardCharsets.UTF_8));
         } else {
             metadata.put(METADATA_MESSAGE_ID_KEY, ByteBuffer.wrap(message.getMessageId().toByteArray()));
         }

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -55,14 +55,12 @@ public class MetadataUtilTest {
 
         Map<String, Object> metadataWithHumanReadableMessageId =
                 MetadataUtil.extractedMetadata(mockRecord, true);
-        Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
+        Assert.assertArrayEquals((byte[]) metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 messageIdString.getBytes(StandardCharsets.UTF_8));
         Assert.assertNotEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
 
         Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false);
         Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
-        Assert.assertNotEquals(metadata.get(METADATA_MESSAGE_ID_KEY),
-                messageIdString.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -57,8 +57,12 @@ public class MetadataUtilTest {
                 MetadataUtil.extractedMetadata(mockRecord, true);
         Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdString.getBytes(StandardCharsets.UTF_8)));
+        Assert.assertNotEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
+                ByteBuffer.wrap(messageIdBytes));
 
         Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false);
         Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
+        Assert.assertNotEquals(metadata.get(METADATA_MESSAGE_ID_KEY),
+                ByteBuffer.wrap(messageIdString.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud;
+
+import static org.apache.pulsar.io.jcloud.util.MetadataUtil.METADATA_MESSAGE_ID_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.util.MetadataUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * metadata utils unit tests.
+ */
+public class MetadataUtilTest {
+    @Test
+    public void testExtractedMetadata() throws IOException {
+        String messageIdString = "1:2:3:4";
+        byte[] messageIdBytes = new byte[]{0x00, 0x01, 0x02, 0x03};
+        Record<GenericRecord> mockRecord = mock(Record.class);
+        Message<GenericRecord> mockMessage = mock(Message.class);
+        MessageId mockMessageId = mock(MessageId.class);
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mockMessage));
+        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
+        when(mockMessage.getProperties()).thenReturn(Collections.emptyMap());
+        when(mockMessage.getSchemaVersion()).thenReturn(new byte[]{0x00});
+        when(mockMessageId.toString()).thenReturn(messageIdString);
+        when(mockMessageId.toByteArray()).thenReturn(messageIdBytes);
+
+        Map<String, Object> metadataWithHumanReadableMessageId =
+                MetadataUtil.extractedMetadata(mockRecord, true);
+        Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
+                ByteBuffer.wrap(messageIdString.getBytes(StandardCharsets.UTF_8)));
+
+        Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false);
+        Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
+    }
+}

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -55,12 +54,12 @@ public class MetadataUtilTest {
 
         Map<String, Object> metadataWithHumanReadableMessageId =
                 MetadataUtil.extractedMetadata(mockRecord, true);
-        Assert.assertArrayEquals((byte[]) metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
-                messageIdString.getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY), messageIdString);
         Assert.assertNotEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
 
         Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false);
         Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
+        Assert.assertNotEquals(metadata.get(METADATA_MESSAGE_ID_KEY), messageIdString);
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -56,13 +56,13 @@ public class MetadataUtilTest {
         Map<String, Object> metadataWithHumanReadableMessageId =
                 MetadataUtil.extractedMetadata(mockRecord, true);
         Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
-                ByteBuffer.wrap(messageIdString.getBytes(StandardCharsets.UTF_8)));
+                messageIdString.getBytes(StandardCharsets.UTF_8));
         Assert.assertNotEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
 
         Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false);
         Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
         Assert.assertNotEquals(metadata.get(METADATA_MESSAGE_ID_KEY),
-                ByteBuffer.wrap(messageIdString.getBytes(StandardCharsets.UTF_8)));
+                messageIdString.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
- added `humanReadableMessageId` in config, default to `false`
- write Pulsar's messageId in `ledgerId:entryId:partitionIndex:batchIndex`
- add tests