### PR TITLE
use fixed size queue to cache messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The Cloud Storage sink connector supports the following properties.
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file. |
+| `pendingQueueSize` | int | False | 20 | The number of records buffered in queue, by default it will always be `batchSize * 2`, and it can be set manually. |
 
 ### Configure Cloud Storage sink connector
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Cloud Storage sink connector supports the following properties.
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file. |
-| `pendingQueueSize` | int | False | 20 | The number of records buffered in queue, by default it will always be `batchSize * 2`, and it can be set manually. |
+| `pendingQueueSize` | int | False | 100 | The number of records buffered in queue, by default it will always be `batchSize * 10`, and it can be set manually. |
 
 ### Configure Cloud Storage sink connector
 

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -74,6 +74,7 @@ The Cloud Storage sink connector supports the following properties.
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file. |
+| `pendingQueueSize` | int | False | 20 | The number of records buffered in queue, by default it will always be `batchSize * 2`, and it can be set manually. |
 
 ## Configure Cloud Storage sink connector
 

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -74,7 +74,7 @@ The Cloud Storage sink connector supports the following properties.
 | `bytesFormatTypeSeparator` | String | False |"0x10" | It is inserted between records for the `formatType` of bytes. By default, it is set to '0x10'. An input record that contains the line separator looks like multiple records in the output object. |
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file. |
-| `pendingQueueSize` | int | False | 20 | The number of records buffered in queue, by default it will always be `batchSize * 2`, and it can be set manually. |
+| `pendingQueueSize` | int | False | 100 | The number of records buffered in queue, by default it will always be `batchSize * 100`, and it can be set manually. |
 
 ## Configure Cloud Storage sink connector
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -148,7 +148,7 @@ public class BlobStoreAbstractConfig implements Serializable {
             pendingQueueSize = batchSize * 10;
         }
         checkArgument(pendingQueueSize > 0, "pendingQueueSize must be a positive integer.");
-        checkArgument(pendingQueueSize < batchSize, "pendingQueueSize must be large than batchSize");
+        checkArgument(pendingQueueSize > batchSize, "pendingQueueSize must be large than batchSize");
     }
 
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -144,7 +144,7 @@ public class BlobStoreAbstractConfig implements Serializable {
                     "bytesFormatTypeSeparator should be a hex encoded string, which starts with '0x'");
         }
 
-        if (pendingQueueSize == -1) {
+        if (pendingQueueSize <= 0) {
             pendingQueueSize = batchSize * 10;
         }
         checkArgument(pendingQueueSize > 0, "pendingQueueSize must be a positive integer.");

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -88,6 +88,7 @@ public class BlobStoreAbstractConfig implements Serializable {
     private boolean sliceTopicPartitionPath;
 
     private int batchSize = 10;
+    private int pendingQueueSize = -1;
 
     private long batchTimeMs = 1000;
 
@@ -142,6 +143,11 @@ public class BlobStoreAbstractConfig implements Serializable {
             checkArgument(!StringUtils.startsWith(bytesFormatTypeSeparator, "0x"),
                     "bytesFormatTypeSeparator should be a hex encoded string, which starts with '0x'");
         }
+
+        if (pendingQueueSize == -1) {
+            pendingQueueSize = batchSize * 2;
+        }
+        checkArgument(pendingQueueSize > 0, "pendingQueueSize must be a positive integer.");
     }
 
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -145,9 +145,10 @@ public class BlobStoreAbstractConfig implements Serializable {
         }
 
         if (pendingQueueSize == -1) {
-            pendingQueueSize = batchSize * 2;
+            pendingQueueSize = batchSize * 10;
         }
         checkArgument(pendingQueueSize > 0, "pendingQueueSize must be a positive integer.");
+        checkArgument(pendingQueueSize < batchSize, "pendingQueueSize must be large than batchSize");
     }
 
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
@@ -90,7 +90,7 @@ public class CloudStorageGenericRecordSink extends BlobStoreAbstractSink<CloudSt
     public CloudStorageSinkConfig loadConfig(Map<String, Object> config, SinkContext sinkContext) throws IOException {
         CloudStorageSinkConfig sinkConfig =
                 IOConfigUtils.loadWithSecrets(config, CloudStorageSinkConfig.class, sinkContext);
-        if (!sinkConfig.isUseDefaultCredentials()) {
+        if (!sinkConfig.isUseDefaultCredentials() && sinkConfig.getProvider().equalsIgnoreCase(PROVIDER_AWSS3)) {
             checkNotNull(sinkConfig.getAccessKeyId(), "accessKeyId property not set.");
             checkNotNull(sinkConfig.getSecretAccessKey(), "secretAccessKey property not set.");
         }

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -62,7 +62,7 @@ public class ConnectorConfigTest {
         Assert.assertEquals(config.get("timePartitionPattern"), cloudStorageSinkConfig.getTimePartitionPattern());
         Assert.assertEquals(config.get("timePartitionDuration"), cloudStorageSinkConfig.getTimePartitionDuration());
         Assert.assertEquals(config.get("batchSize"), cloudStorageSinkConfig.getBatchSize());
-        Assert.assertEquals((int)config.get("batchSize") * 10, cloudStorageSinkConfig.getPendingQueueSize());
+        Assert.assertEquals((int) config.get("batchSize") * 10, cloudStorageSinkConfig.getPendingQueueSize());
     }
 
     @Test

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -52,7 +52,6 @@ public class ConnectorConfigTest {
         CloudStorageSinkConfig cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
         cloudStorageSinkConfig.validate();
 
-
         Assert.assertEquals(PROVIDER_AWSS3, cloudStorageSinkConfig.getProvider());
         Assert.assertEquals(config.get("accessKeyId"), cloudStorageSinkConfig.getAccessKeyId());
         Assert.assertEquals(config.get("secretAccessKey"), cloudStorageSinkConfig.getSecretAccessKey());
@@ -63,6 +62,7 @@ public class ConnectorConfigTest {
         Assert.assertEquals(config.get("timePartitionPattern"), cloudStorageSinkConfig.getTimePartitionPattern());
         Assert.assertEquals(config.get("timePartitionDuration"), cloudStorageSinkConfig.getTimePartitionDuration());
         Assert.assertEquals(config.get("batchSize"), cloudStorageSinkConfig.getBatchSize());
+        Assert.assertEquals((int)config.get("batchSize") * 10, cloudStorageSinkConfig.getPendingQueueSize());
     }
 
     @Test


### PR DESCRIPTION
- use fixed size queue to prevent caching too many messages
- add `pendingQueueSize` to allow custom queue size
- by default the `pendingQueueSize` will be `batchSize * 10`