### PR TITLE
fix `timePartitioner` duration validation

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -125,7 +125,7 @@ public class BlobStoreAbstractConfig implements Serializable {
                 );
             }
             if (StringUtils.isNoneBlank(timePartitionDuration)) {
-                checkArgument(Pattern.matches("^\\d+[dhDH]$", timePartitionDuration), "timePartitionDuration invalid.");
+                checkArgument(Pattern.matches("^\\d+[dhDHms]?$", timePartitionDuration), "timePartitionDuration invalid.");
             }
         }
         checkArgument(batchSize > 0, "batchSize must be a positive integer.");

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -125,7 +125,8 @@ public class BlobStoreAbstractConfig implements Serializable {
                 );
             }
             if (StringUtils.isNoneBlank(timePartitionDuration)) {
-                checkArgument(Pattern.matches("^\\d+[dhDHms]?$", timePartitionDuration), "timePartitionDuration invalid.");
+                checkArgument(Pattern.matches("^\\d+[dhDHms]?$", timePartitionDuration),
+                        "timePartitionDuration invalid.");
             }
         }
         checkArgument(batchSize > 0, "batchSize must be a positive integer.");

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -87,8 +87,8 @@ public class ConnectorConfigTest {
         try {
             config.put("timePartitionDuration", "1000");
             CloudStorageSinkConfig.load(config).validate();
-            Assert.fail();
         } catch (Exception e) {
+            Assert.fail();
         }
         try {
             config.put("timePartitionDuration", "1000h");
@@ -98,6 +98,20 @@ public class ConnectorConfigTest {
         }
         try {
             config.put("timePartitionDuration", "1000d");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "1000m");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "1000s");
             CloudStorageSinkConfig.load(config).validate();
         } catch (Exception e) {
             Assert.fail();
@@ -188,69 +202,5 @@ public class ConnectorConfigTest {
         Assert.assertEquals(sinkConfig.getBucket(), "testbucket");
         Assert.assertEquals(sinkConfig.getSecretAccessKey(), "myAccessKey");
         Assert.assertEquals(sinkConfig.getAccessKeyId(), "myKeyId");
-    }
-
-    @Test
-    public final void timePartitionerDurationTest() throws IOException {
-        Map<String, Object> config = new HashMap<>();
-        config.put("provider", "aws-s3");
-        config.put("bucket", "testbucket");
-        config.put("accessKeyId", "aws-s3");
-        config.put("secretAccessKey", "aws-s3");
-        config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
-        config.put("formatType", "avro");
-        config.put("partitionerType", "default");
-        config.put("timePartitionPattern", "yyyy-MM-dd");
-        config.put("batchSize", 10);
-
-        try {
-            config.put("timePartitionDuration", "2d");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "3D");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "2h");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "3H");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "10m");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "60s");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-
-        try {
-            config.put("timePartitionDuration", "60000");
-            CloudStorageSinkConfig.load(config).validate();
-        } catch (Exception e) {
-            Assert.fail();
-        }
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -195,6 +195,8 @@ public class ConnectorConfigTest {
         Map<String, Object> config = new HashMap<>();
         config.put("provider", "aws-s3");
         config.put("bucket", "testbucket");
+        config.put("accessKeyId", "aws-s3");
+        config.put("secretAccessKey", "aws-s3");
         config.put("region", "localhost");
         config.put("endpoint", "us-standard");
         config.put("formatType", "avro");

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -189,4 +189,66 @@ public class ConnectorConfigTest {
         Assert.assertEquals(sinkConfig.getSecretAccessKey(), "myAccessKey");
         Assert.assertEquals(sinkConfig.getAccessKeyId(), "myKeyId");
     }
+
+    @Test
+    public final void timePartitionerDurationTest() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", "aws-s3");
+        config.put("bucket", "testbucket");
+        config.put("region", "localhost");
+        config.put("endpoint", "us-standard");
+        config.put("formatType", "avro");
+        config.put("partitionerType", "default");
+        config.put("timePartitionPattern", "yyyy-MM-dd");
+        config.put("batchSize", 10);
+
+        try {
+            config.put("timePartitionDuration", "2d");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "3D");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "2h");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "3H");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "10m");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "60s");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("timePartitionDuration", "60000");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/streamnative/pulsar-io-cloud-storage/pull/163 supports more scales of time partitioner, but havnt change the config validator and will prevent user using the latest feature. This PR fixes the validator and add some more unit tests.