### PR TITLE
fix `bytesFormatTypeSeparator` checkArgument with false condition

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -139,7 +139,7 @@ public class BlobStoreAbstractConfig implements Serializable {
         }
 
         if ("bytes".equalsIgnoreCase(formatType)) {
-            checkArgument(StringUtils.isEmpty(bytesFormatTypeSeparator),
+            checkArgument(StringUtils.isNotEmpty(bytesFormatTypeSeparator),
                     "bytesFormatTypeSeparator cannot be empty when formatType is 'bytes'");
             checkArgument(!StringUtils.startsWith(bytesFormatTypeSeparator, "0x"),
                     "bytesFormatTypeSeparator should be a hex encoded string, which starts with '0x'");

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -141,7 +141,7 @@ public class BlobStoreAbstractConfig implements Serializable {
         if ("bytes".equalsIgnoreCase(formatType)) {
             checkArgument(StringUtils.isNotEmpty(bytesFormatTypeSeparator),
                     "bytesFormatTypeSeparator cannot be empty when formatType is 'bytes'");
-            checkArgument(!StringUtils.startsWith(bytesFormatTypeSeparator, "0x"),
+            checkArgument(StringUtils.startsWith(bytesFormatTypeSeparator, "0x"),
                     "bytesFormatTypeSeparator should be a hex encoded string, which starts with '0x'");
         }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -203,4 +203,37 @@ public class ConnectorConfigTest {
         Assert.assertEquals(sinkConfig.getSecretAccessKey(), "myAccessKey");
         Assert.assertEquals(sinkConfig.getAccessKeyId(), "myKeyId");
     }
+
+    @Test
+    public void byteConfigTest() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", PROVIDER_AWSS3);
+        config.put("accessKeyId", "aws-s3");
+        config.put("secretAccessKey", "aws-s3");
+        config.put("bucket", "testbucket");
+        config.put("region", "localhost");
+        config.put("endpoint", "us-standard");
+        config.put("pathPrefix", "pulsar/");
+        config.put("formatType", "bytes");
+        config.put("partitionerType", "default");
+        config.put("timePartitionPattern", "yyyy-MM-dd");
+        config.put("timePartitionDuration", "2d");
+        config.put("batchSize", 10);
+        config.put("bytesFormatTypeSeparator", "0x10");
+        CloudStorageSinkConfig cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
+        cloudStorageSinkConfig.validate();
+
+        Assert.assertEquals(PROVIDER_AWSS3, cloudStorageSinkConfig.getProvider());
+        Assert.assertEquals(config.get("accessKeyId"), cloudStorageSinkConfig.getAccessKeyId());
+        Assert.assertEquals(config.get("secretAccessKey"), cloudStorageSinkConfig.getSecretAccessKey());
+        Assert.assertEquals(config.get("bucket"), cloudStorageSinkConfig.getBucket());
+        Assert.assertEquals(config.get("region"), cloudStorageSinkConfig.getRegion());
+        Assert.assertEquals(config.get("formatType"), cloudStorageSinkConfig.getFormatType());
+        Assert.assertEquals(config.get("partitionerType"), cloudStorageSinkConfig.getPartitionerType());
+        Assert.assertEquals(config.get("timePartitionPattern"), cloudStorageSinkConfig.getTimePartitionPattern());
+        Assert.assertEquals(config.get("timePartitionDuration"), cloudStorageSinkConfig.getTimePartitionDuration());
+        Assert.assertEquals(config.get("batchSize"), cloudStorageSinkConfig.getBatchSize());
+        Assert.assertEquals(config.get("bytesFormatTypeSeparator"), cloudStorageSinkConfig.getBytesFormatTypeSeparator());
+        Assert.assertEquals((int) config.get("batchSize") * 10, cloudStorageSinkConfig.getPendingQueueSize());
+    }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -233,7 +233,8 @@ public class ConnectorConfigTest {
         Assert.assertEquals(config.get("timePartitionPattern"), cloudStorageSinkConfig.getTimePartitionPattern());
         Assert.assertEquals(config.get("timePartitionDuration"), cloudStorageSinkConfig.getTimePartitionDuration());
         Assert.assertEquals(config.get("batchSize"), cloudStorageSinkConfig.getBatchSize());
-        Assert.assertEquals(config.get("bytesFormatTypeSeparator"), cloudStorageSinkConfig.getBytesFormatTypeSeparator());
+        Assert.assertEquals(config.get("bytesFormatTypeSeparator"),
+                cloudStorageSinkConfig.getBytesFormatTypeSeparator());
         Assert.assertEquals((int) config.get("batchSize") * 10, cloudStorageSinkConfig.getPendingQueueSize());
     }
 }


### PR DESCRIPTION
when using `bytes` format, `bytesFormatTypeSeparator` needs to be set and the `checkArgument` is using false condition, which will cause the bytes format cannot be used as expected.