### PR TITLE
add `useHumanReadableSchemaVersion` to support plain format of schemaVersion in message metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The Cloud Storage sink connector supports the following properties.
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.                                                                    |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file.                                                                                              |
 | `pendingQueueSize` | int | False | 100 | The number of records buffered in queue, by default it will always be `batchSize * 10`, and it can be set manually.                                                                                              |
+| `useHumanReadableSchemaVersion` | Boolean | False |false | Use human-readable format string for schema version in message metadata, the schema version will be in plain string format. Otherwise, the schema version will be in hex-encoded string.                         |
 
 ### Configure Cloud Storage sink connector
 

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -75,6 +75,7 @@ The Cloud Storage sink connector supports the following properties.
 | `gcsServiceAccountKeyFilePath` | String | False | "" | Path to the GCS credentials file. If empty, the credentials file will be read from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.                                                                    |
 | `gcsServiceAccountKeyFileContent` | String | False | "" | The contents of the JSON service key file. If empty, credentials are read from `gcsServiceAccountKeyFilePath` file.                                                                                              |
 | `pendingQueueSize` | int | False | 100 | The number of records buffered in queue, by default it will always be `batchSize * 100`, and it can be set manually.                                                                                             |
+| `useHumanReadableSchemaVersion` | Boolean | False |false | Use human-readable format string for schema version in message metadata, the schema version will be in plain string format. Otherwise, the schema version will be in hex-encoded string.                         |
 
 ## Configure Cloud Storage sink connector
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -99,6 +99,7 @@ public class BlobStoreAbstractConfig implements Serializable {
 
     private boolean withMetadata;
     private boolean useHumanReadableMessageId = false;
+    private boolean useHumanReadableSchemaVersion = false;
     private boolean withTopicPartitionNumber = true;
     private String bytesFormatTypeSeparator = "0x10";
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -98,8 +98,8 @@ public class BlobStoreAbstractConfig implements Serializable {
     private String awsCannedAcl = "";
 
     private boolean withMetadata;
-    private boolean useHumanReadableMessageId = false;
-    private boolean useHumanReadableSchemaVersion = false;
+    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableSchemaVersion;
     private boolean withTopicPartitionNumber = true;
     private String bytesFormatTypeSeparator = "0x10";
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -46,8 +46,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId = false;
-    private boolean useHumanReadableSchemaVersion = false;
+    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableSchemaVersion;
     private CodecFactory codecFactory;
 
     @Override

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -46,7 +46,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableMessageId = false;
+    private boolean useHumanReadableSchemaVersion = false;
     private CodecFactory codecFactory;
 
     @Override
@@ -58,6 +59,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
+        this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
         String codecName = configuration.getAvroCodec();
         if (codecName == null) {
             this.codecFactory = CodecFactory.nullCodec();
@@ -77,7 +79,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     public void initSchema(org.apache.pulsar.client.api.Schema<GenericRecord> schema) {
         rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         if (useMetadata){
-            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema, useHumanReadableMessageId);
+            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema,
+                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
         }
     }
 
@@ -93,7 +96,8 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
 
                 if (useMetadata) {
                     org.apache.avro.generic.GenericRecord metadataRecord =
-                            MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
+                            MetadataUtil.extractedMetadataRecord(next,
+                                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 fileWriter.append(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -45,8 +45,8 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private ObjectMapper objectMapper;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId = false;
-    private boolean useHumanReadableSchemaVersion = false;
+    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableSchemaVersion;
 
     @Override
     public String getExtension() {

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -45,7 +45,8 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private ObjectMapper objectMapper;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableMessageId = false;
+    private boolean useHumanReadableSchemaVersion = false;
 
     @Override
     public String getExtension() {
@@ -56,6 +57,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
+        this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
     }
 
     @Override
@@ -73,7 +75,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             Map<String, Object> writeValue = convertRecordToObject(next.getValue());
             if (useMetadata) {
                 writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY,
-                        MetadataUtil.extractedMetadata(next, useHumanReadableMessageId));
+                        MetadataUtil.extractedMetadata(next, useHumanReadableMessageId, useHumanReadableSchemaVersion));
             }
             String recordAsString = objectMapper.writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -45,8 +45,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId = false;
-    private boolean useHumanReadableSchemaVersion = false;
+    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableSchemaVersion;
 
     @Override
     public String getExtension() {

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -45,7 +45,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     private Schema rootAvroSchema;
 
     private boolean useMetadata;
-    private boolean useHumanReadableMessageId;
+    private boolean useHumanReadableMessageId = false;
+    private boolean useHumanReadableSchemaVersion = false;
 
     @Override
     public String getExtension() {
@@ -56,13 +57,15 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     public void configure(BlobStoreAbstractConfig configuration) {
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
+        this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
     }
 
     @Override
     public void initSchema(org.apache.pulsar.client.api.Schema<GenericRecord> schema) {
         rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         if (useMetadata){
-            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema, useHumanReadableMessageId);
+            rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema,
+                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
         }
     }
 
@@ -86,7 +89,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                         .convertGenericRecord(next.getValue(), rootAvroSchema);
                 if (useMetadata) {
                     org.apache.avro.generic.GenericRecord metadataRecord =
-                            MetadataUtil.extractedMetadataRecord(next, useHumanReadableMessageId);
+                            MetadataUtil.extractedMetadataRecord(next,
+                                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 parquetWriter.write(writeRecord);


### PR DESCRIPTION
fix https://github.com/streamnative/pulsar-io-cloud-storage/issues/256
add `useHumanReadableSchemaVersion`
support convert schema version to plain string format instead of hex-encoded string