### PR TITLE
fix schema version format

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/MetadataUtil.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.io.jcloud.util;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -53,7 +52,8 @@ public class MetadataUtil {
                 useHumanReadableMessageId, useHumanReadableSchemaVersion));
         record.put(METADATA_PROPERTIES_KEY, message.getProperties());
         if (useHumanReadableMessageId) {
-            record.put(METADATA_SCHEMA_VERSION_KEY, new String(message.getSchemaVersion(), StandardCharsets.UTF_8));
+            record.put(METADATA_SCHEMA_VERSION_KEY,
+                    MetadataUtil.parseSchemaVersionFromBytes(message.getSchemaVersion()));
         } else {
             record.put(METADATA_SCHEMA_VERSION_KEY, ByteBuffer.wrap(message.getSchemaVersion()));
         }
@@ -80,7 +80,8 @@ public class MetadataUtil {
         final Message<GenericRecord> message = next.getMessage().get();
         metadata.put(METADATA_PROPERTIES_KEY, message.getProperties());
         if (useHumanReadableSchemaVersion) {
-            metadata.put(METADATA_SCHEMA_VERSION_KEY, new String(message.getSchemaVersion(), StandardCharsets.UTF_8));
+            metadata.put(METADATA_SCHEMA_VERSION_KEY,
+                    MetadataUtil.parseSchemaVersionFromBytes(message.getSchemaVersion()));
         } else {
             metadata.put(METADATA_SCHEMA_VERSION_KEY, message.getSchemaVersion());
         }
@@ -139,7 +140,7 @@ public class MetadataUtil {
                 ))
         );
         if (useHumanReadableSchemaVersion) {
-            fields.add(new Schema.Field(METADATA_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.STRING)));
+            fields.add(new Schema.Field(METADATA_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.LONG)));
         } else {
             fields.add(new Schema.Field(METADATA_SCHEMA_VERSION_KEY, Schema.create(Schema.Type.BYTES)));
         }
@@ -154,5 +155,10 @@ public class MetadataUtil {
                 false,
                 fields
         );
+    }
+
+    public static long parseSchemaVersionFromBytes(byte[] schemaVersion) {
+        ByteBuffer bb = ByteBuffer.wrap(schemaVersion);
+        return bb.getLong();
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -43,7 +42,7 @@ public class MetadataUtilTest {
     @Test
     public void testExtractedMetadata() throws IOException {
         String messageIdString = "1:2:3:4";
-        byte[] schemaVersionBytes = new byte[]{0x0A};
+        byte[] schemaVersionBytes = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A};
         byte[] messageIdBytes = new byte[]{0x00, 0x01, 0x02, 0x03};
         Record<GenericRecord> mockRecord = mock(Record.class);
         Message<GenericRecord> mockMessage = mock(Message.class);
@@ -61,7 +60,7 @@ public class MetadataUtilTest {
         Assert.assertNotEquals(metadataWithHumanReadableMetadata.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
         Assert.assertEquals(metadataWithHumanReadableMetadata.get(METADATA_SCHEMA_VERSION_KEY),
-                new String(schemaVersionBytes, StandardCharsets.UTF_8));
+                MetadataUtil.parseSchemaVersionFromBytes(schemaVersionBytes));
 
         Map<String, Object> metadataWithHumanReadableMessageId =
                 MetadataUtil.extractedMetadata(mockRecord, true, false);


### PR DESCRIPTION
change the schema version into Long type, sample: `"__message_metadata__":{"schemaVersion":0,"messageId":"10:427:-1:0","properties":{}}`