### PR TITLE
[security] Upgrade vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,17 @@
     <testRetryCount>2</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.11.3</jackson.version>
+    <jackson.version>2.13.2</jackson.version>
     <lombok.version>1.16.22</lombok.version>
     <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
-    <parquet.version>1.12.0</parquet.version>
+    <parquet.version>1.12.2</parquet.version>
     <awsjavasdk.version>1.12.148</awsjavasdk.version>
     <aws.java.sdk2.version>2.16.1</aws.java.sdk2.version>
     <jaxb-api>2.3.1</jaxb-api>
-    <gson.version>2.8.6</gson.version>
+    <gson.version>2.8.9</gson.version>
+    <commons-compress.version>1.21</commons-compress.version>
+    <log4j.version>2.17.1</log4j.version>
+    <json-smart.version>2.4.7</json-smart.version>
 
     <!-- test dependencies -->
     <junit.version>4.13.1</junit.version>
@@ -140,6 +143,21 @@
             <artifactId>avro</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${gson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
       </dependency>
       <!-- test dependencies -->
       <dependency>
@@ -287,7 +305,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>3.3.0</version>
+      <version>3.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
@@ -314,7 +332,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>3.3.0</version>
+      <version>3.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
@@ -340,12 +358,11 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.woodstox</groupId>
-      <artifactId>woodstox-core</artifactId>
-      <version>5.0.3</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -387,8 +404,31 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
### Motivation
There are a couple of vulnerable dependencies with CVE with critical severity.

### Modifications
* Jackson: 2.11.3 -> 2.13.2
* parquet: 1.12.0 -> 1.12.2
* gson: 2.8.6 -> 2.8.9
* commons-compress: 1.20 -> 1.21
* removed Log4J 1 and added log4j2 api
* json-smart: 2.4.3 to 2.4.7
* Hadoop 3.3.0 to 3.3.1
* Removed Woodstock forced version. Still present in the classpath the 5.3.0 version
