### PR TITLE
[security] Upgrade jackson-databind to get rid of CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 
     <!-- connector dependencies -->
     <jackson.version>2.13.2</jackson.version>
+    <jackson-databind.version>2.13.2.1</jackson-databind.version>
     <lombok.version>1.16.22</lombok.version>
     <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
     <parquet.version>1.12.2</parquet.version>
@@ -95,7 +96,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
See Pulsar related pull https://github.com/apache/pulsar/pull/14871
- [x] `no-need-doc` 
  
  