### PR TITLE
#268 add protobuf parquet writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,12 @@ Before using the Cloud Storage sink connector, you need to create a configuratio
 Cloud Storage Sink Connector provides multiple output format options, including JSON, Avro, Bytes, or Parquet. The default format is JSON.
 With current implementation, there are some limitations for different formats:
 
-- JSON: only support structured Pulsar schema types, including `JSON`, `PROTOBUF`, `AVRO`, and `PROTOBUF_NATIVE`. The connector will try to convert the data with a `String` or `Bytes` format to JSON-format data.
-- Avro / Parquet: only support structured Pulsar schema types, including `JSON`, `PROTOBUF`, `AVRO`, and `PROTOBUF_NATIVE`.
+- JSON: only support structured Pulsar schema types, including `JSON`, `PROTOBUF`, `AVRO`. The connector will try to convert the data with a `String` or `Bytes` format to JSON-format data.
+- Avro: only support structured Pulsar schema types, including `JSON`, `PROTOBUF`, `AVRO`. 
+- Parquet: only support structured Pulsar schema types, including `JSON`, `PROTOBUF`, `AVRO`, and `PROTOBUF_NATIVE`. 
 - Bytes: support all Pulsar schema types.
+
+> Note: When using `Parquet` with `PROTOBUF_NATIVE` format, the connector will write the messages with `DynamicMessage` format, when `withMetadata` is set to `true`, the connector will add `__message_metadata__` to the messages with `PulsarIOCSCProtobufMessageMetadata` format. 
 
 By default, when the connector receives a message with a non-supported schema type, the connector will `fail` the message. If you want to skip the non-supported messages, you can set `skipFailedMessages` to `true`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
     <commons-compress.version>1.21</commons-compress.version>
     <log4j.version>2.17.1</log4j.version>
     <json-smart.version>2.4.7</json-smart.version>
+    <protobuf3.version>3.16.1</protobuf3.version>
+    <protoc3.version>${protobuf3.version}</protoc3.version>
+    <grpc.version>1.42.1</grpc.version>
+    <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
 
     <!-- test dependencies -->
     <junit.version>4.13.1</junit.version>
@@ -70,6 +74,8 @@
     <nifi.nar.plugin.version>1.2.0</nifi.nar.plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+    <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -133,6 +139,18 @@
             <artifactId>avro</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf3.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.parquet</groupId>
+        <artifactId>parquet-protobuf</artifactId>
+        <version>${parquet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
@@ -287,6 +305,18 @@
           <artifactId>avro</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-protobuf</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -630,9 +660,34 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${os-maven-plugin.version}</version>
+      </extension>
+    </extensions>
 
     <plugins>
       <!-- compile -->
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>${protobuf-maven-plugin.version}</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
+          <checkStaleness>true</checkStaleness>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.jcloud.format;
 
+import static org.apache.pulsar.common.schema.SchemaType.PROTOBUF_NATIVE;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -98,7 +99,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
                 final Record<GenericRecord> next = records.next();
                 GenericRecord genericRecord = next.getValue();
                 if (genericRecord.getSchemaType() == SchemaType.BYTES
-                        && internalSchema.getSchemaInfo().getType() == SchemaType.PROTOBUF_NATIVE) {
+                        && internalSchema.getSchemaInfo().getType() == PROTOBUF_NATIVE) {
                     genericRecord = internalSchema.decode((byte[]) next.getValue().getNativeObject());
                 }
                 org.apache.avro.generic.GenericRecord writeRecord = AvroRecordUtil

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufDescriptorWriteSupport.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufDescriptorWriteSupport.java
@@ -1,0 +1,610 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.format.parquet;
+
+import static java.util.Optional.ofNullable;
+import static org.apache.parquet.proto.ProtoConstants.METADATA_ENUM_ITEM_SEPARATOR;
+import static org.apache.parquet.proto.ProtoConstants.METADATA_ENUM_KEY_VALUE_SEPARATOR;
+import static org.apache.parquet.proto.ProtoConstants.METADATA_ENUM_PREFIX;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.twitter.elephantbird.util.Protobufs;
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.BadConfigurationException;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.proto.ProtoReadSupport;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.IncompatibleSchemaModificationException;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+/**
+ * A {@link WriteSupport} for writing protobuf messages.
+ */
+@Slf4j
+public class ProtobufDescriptorWriteSupport<T extends MessageOrBuilder> extends WriteSupport<T> {
+
+    public static final String PB_CLASS_WRITE = "parquet.proto.writeClass";
+    // PARQUET-968 introduces changes to allow writing specs compliant schemas with parquet-protobuf.
+    // In the past, collection were not written using the LIST and MAP wrappers and thus were not compliant
+    // with the parquet specs. This flag, is set to true, allows to write using spec compliant schemas
+    // but is set to false by default to keep backward compatibility
+    public static final String PB_SPECS_COMPLIANT_WRITE = "parquet.proto.writeSpecsCompliant";
+    // Keep protobuf enum value with number in the metadata, so that in read time, a reader can read at least
+    // the number back even with an outdated schema which might not contain all enum values.
+    private final Map<String, Map<String, Integer>> protoEnumBookKeeper = new HashMap<>();
+    private boolean writeSpecsCompliant = false;
+    private RecordConsumer recordConsumer;
+    private Class<? extends Message> protoMessage;
+    private Descriptors.Descriptor descriptor;
+    private MessageWriter messageWriter;
+
+    public ProtobufDescriptorWriteSupport(Class<? extends Message> protobufClass) {
+        this.protoMessage = protobufClass;
+    }
+
+    public ProtobufDescriptorWriteSupport(Descriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    public static void setSchema(Configuration configuration, Class<? extends Message> protoClass) {
+        configuration.setClass(PB_CLASS_WRITE, protoClass, Message.class);
+    }
+
+    /**
+     * Make parquet-protobuf use the LIST and MAP wrappers for collections. Set to false if you need backward
+     * compatibility with parquet before PARQUET-968 (1.9.0 and older).
+     *
+     * @param configuration       The hadoop configuration
+     * @param writeSpecsCompliant If set to true, the old schema style will be used (without wrappers).
+     */
+    public static void setWriteSpecsCompliant(Configuration configuration, boolean writeSpecsCompliant) {
+        configuration.setBoolean(PB_SPECS_COMPLIANT_WRITE, writeSpecsCompliant);
+    }
+
+    @Override
+    public String getName() {
+        return "protobuf";
+    }
+
+    /**
+     * Writes Protocol buffer to parquet file.
+     *
+     * @param record instance of Message.Builder or Message.
+     */
+    @Override
+    public void write(T record) {
+        recordConsumer.startMessage();
+        try {
+            messageWriter.writeTopLevelMessage(record);
+        } catch (RuntimeException e) {
+            Message m = (record instanceof Message.Builder) ? ((Message.Builder) record).build() : (Message) record;
+            log.error("Cannot write message " + e.getMessage() + " : " + m);
+            throw e;
+        }
+        recordConsumer.endMessage();
+    }
+
+    @Override
+    public void prepareForWrite(RecordConsumer recordConsumer) {
+        this.recordConsumer = recordConsumer;
+    }
+
+    @Override
+    public WriteContext init(Configuration configuration) {
+
+        // if no protobuf descriptor was given in constructor, load descriptor from configuration (set with
+        // setProtobufClass)
+        if (descriptor == null) {
+            if (protoMessage == null) {
+                Class<? extends Message> pbClass = configuration.getClass(PB_CLASS_WRITE, null, Message.class);
+                if (pbClass != null) {
+                    protoMessage = pbClass;
+                } else {
+                    String msg = "Protocol buffer class or descriptor not specified.";
+                    String hint =
+                            " Please use method ProtoParquetOutputFormat.setProtobufClass(...) or other similar "
+                                    + "method.";
+                    throw new BadConfigurationException(msg + hint);
+                }
+            }
+            descriptor = Protobufs.getMessageDescriptor(protoMessage);
+        } else {
+            //Assume no specific Message extending class, so use DynamicMessage
+            protoMessage = DynamicMessage.class;
+        }
+
+        writeSpecsCompliant = configuration.getBoolean(PB_SPECS_COMPLIANT_WRITE, writeSpecsCompliant);
+        MessageType rootSchema = new ProtobufSchemaConverter(writeSpecsCompliant).convert(descriptor);
+        validatedMapping(descriptor, rootSchema);
+
+        this.messageWriter = new MessageWriter(descriptor, rootSchema);
+
+        Map<String, String> extraMetaData = new HashMap<>();
+        extraMetaData.put(ProtoReadSupport.PB_CLASS, protoMessage.getName());
+        extraMetaData.put(ProtoReadSupport.PB_DESCRIPTOR, descriptor.toProto().toString());
+        extraMetaData.put(PB_SPECS_COMPLIANT_WRITE, String.valueOf(writeSpecsCompliant));
+        return new WriteContext(rootSchema, extraMetaData);
+    }
+
+    @Override
+    public FinalizedWriteContext finalizeWrite() {
+        Map<String, String> protoMetadata = enumMetadata();
+        return new FinalizedWriteContext(protoMetadata);
+    }
+
+    private Map<String, String> enumMetadata() {
+        Map<String, String> enumMetadata = new HashMap<>();
+        for (Map.Entry<String, Map<String, Integer>> enumNameNumberMapping : protoEnumBookKeeper.entrySet()) {
+            StringBuilder nameNumberPairs = new StringBuilder();
+            if (enumNameNumberMapping.getValue().isEmpty()) {
+                // No enum is ever written to any column of this file, put an empty string as the value in the metadata
+                log.info("No enum is written for " + enumNameNumberMapping.getKey());
+            }
+            int idx = 0;
+            for (Map.Entry<String, Integer> nameNumberPair : enumNameNumberMapping.getValue().entrySet()) {
+                nameNumberPairs.append(nameNumberPair.getKey())
+                        .append(METADATA_ENUM_KEY_VALUE_SEPARATOR)
+                        .append(nameNumberPair.getValue());
+                idx++;
+                if (idx < enumNameNumberMapping.getValue().size()) {
+                    nameNumberPairs.append(METADATA_ENUM_ITEM_SEPARATOR);
+                }
+            }
+            enumMetadata.put(METADATA_ENUM_PREFIX + enumNameNumberMapping.getKey(), nameNumberPairs.toString());
+        }
+        return enumMetadata;
+    }
+
+    /**
+     * validates mapping between protobuffer fields and parquet fields.
+     */
+    private void validatedMapping(Descriptor descriptor, GroupType parquetSchema) {
+        List<FieldDescriptor> allFields = descriptor.getFields();
+
+        for (FieldDescriptor fieldDescriptor : allFields) {
+            String fieldName = fieldDescriptor.getName();
+            int fieldIndex = fieldDescriptor.getIndex();
+            int parquetIndex = parquetSchema.getFieldIndex(fieldName);
+            if (fieldIndex != parquetIndex) {
+                String message = "FieldIndex mismatch name=" + fieldName + ": " + fieldIndex + " != " + parquetIndex;
+                throw new IncompatibleSchemaModificationException(message);
+            }
+        }
+    }
+
+    private FieldWriter unknownType(FieldDescriptor fieldDescriptor) {
+        String exceptionMsg = "Unknown type with descriptor \"" + fieldDescriptor
+                + "\" and type \"" + fieldDescriptor.getJavaType() + "\".";
+        throw new InvalidRecordException(exceptionMsg);
+    }
+
+    class FieldWriter {
+        String fieldName;
+        int index = -1;
+
+        void setFieldName(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        /**
+         * sets index of field inside parquet message.
+         */
+        void setIndex(int index) {
+            this.index = index;
+        }
+
+        /**
+         * Used for writing repeated fields.
+         */
+        void writeRawValue(Object value) {
+
+        }
+
+        /**
+         * Used for writing nonrepeated (optional, required) fields.
+         */
+        void writeField(Object value) {
+            if (!(this instanceof ProtobufDescriptorWriteSupport.MapWriter)) {
+                recordConsumer.startField(fieldName, index);
+            }
+            writeRawValue(value);
+            if (!(this instanceof ProtobufDescriptorWriteSupport.MapWriter)) {
+                recordConsumer.endField(fieldName, index);
+            }
+        }
+    }
+
+    class MessageWriter extends FieldWriter {
+
+        final FieldWriter[] fieldWriters;
+
+        @SuppressWarnings("unchecked")
+        MessageWriter(Descriptor descriptor, GroupType schema) {
+            List<FieldDescriptor> fields = descriptor.getFields();
+            fieldWriters = (FieldWriter[]) Array.newInstance(FieldWriter.class, fields.size());
+
+            for (FieldDescriptor fieldDescriptor : fields) {
+                String name = fieldDescriptor.getName();
+                Type type = schema.getType(name);
+                FieldWriter writer = createWriter(fieldDescriptor, type);
+
+                if (writeSpecsCompliant && fieldDescriptor.isRepeated() && !fieldDescriptor.isMapField()) {
+                    writer = new ArrayWriter(writer);
+                } else if (!writeSpecsCompliant && fieldDescriptor.isRepeated()) {
+                    // the old schemas style used to write maps as repeated fields instead of wrapping them in a LIST
+                    writer = new RepeatedWriter(writer);
+                }
+
+                writer.setFieldName(name);
+                writer.setIndex(schema.getFieldIndex(name));
+
+                fieldWriters[fieldDescriptor.getIndex()] = writer;
+            }
+        }
+
+        private FieldWriter createWriter(FieldDescriptor fieldDescriptor, Type type) {
+
+            switch (fieldDescriptor.getJavaType()) {
+                case STRING:
+                    return new StringWriter();
+                case MESSAGE:
+                    return createMessageWriter(fieldDescriptor, type);
+                case INT:
+                    return new IntWriter();
+                case LONG:
+                    return new LongWriter();
+                case FLOAT:
+                    return new FloatWriter();
+                case DOUBLE:
+                    return new DoubleWriter();
+                case ENUM:
+                    return new EnumWriter(fieldDescriptor.getEnumType());
+                case BOOLEAN:
+                    return new BooleanWriter();
+                case BYTE_STRING:
+                    return new BinaryWriter();
+            }
+
+            return unknownType(fieldDescriptor); //should not be executed, always throws exception.
+        }
+
+        private FieldWriter createMessageWriter(FieldDescriptor fieldDescriptor, Type type) {
+            if (fieldDescriptor.isMapField() && writeSpecsCompliant) {
+                return createMapWriter(fieldDescriptor, type);
+            }
+
+            return new MessageWriter(fieldDescriptor.getMessageType(), getGroupType(type));
+        }
+
+        private GroupType getGroupType(Type type) {
+            LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+            if (logicalTypeAnnotation == null) {
+                return type.asGroupType();
+            }
+            return logicalTypeAnnotation.accept(new LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<GroupType>() {
+                @Override
+                public Optional<GroupType> visit(LogicalTypeAnnotation.ListLogicalTypeAnnotation listLogicalType) {
+                    return ofNullable(
+                            type.asGroupType().getType("list").asGroupType().getType("element").asGroupType());
+                }
+
+                @Override
+                public Optional<GroupType> visit(LogicalTypeAnnotation.MapLogicalTypeAnnotation mapLogicalType) {
+                    return ofNullable(
+                            type.asGroupType().getType("key_value").asGroupType().getType("value").asGroupType());
+                }
+            }).orElse(type.asGroupType());
+        }
+
+        private MapWriter createMapWriter(FieldDescriptor fieldDescriptor, Type type) {
+            List<FieldDescriptor> fields = fieldDescriptor.getMessageType().getFields();
+            if (fields.size() != 2) {
+                throw new UnsupportedOperationException(
+                        "Expected two fields for the map (key/value), but got: " + fields);
+            }
+
+            // KeyFieldWriter
+            FieldDescriptor keyProtoField = fields.get(0);
+            FieldWriter keyWriter = createWriter(keyProtoField, type);
+            keyWriter.setFieldName(keyProtoField.getName());
+            keyWriter.setIndex(0);
+
+            // ValueFieldWriter
+            FieldDescriptor valueProtoField = fields.get(1);
+            FieldWriter valueWriter = createWriter(valueProtoField, type);
+            valueWriter.setFieldName(valueProtoField.getName());
+            valueWriter.setIndex(1);
+
+            return new MapWriter(keyWriter, valueWriter);
+        }
+
+        /**
+         * Writes top level message. It cannot call startGroup().
+         */
+        void writeTopLevelMessage(Object value) {
+            writeAllFields((MessageOrBuilder) value);
+        }
+
+        /**
+         * Writes message as part of repeated field. It cannot start field.
+         */
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.startGroup();
+            writeAllFields((MessageOrBuilder) value);
+            recordConsumer.endGroup();
+        }
+
+        /**
+         * Used for writing nonrepeated (optional, required) fields.
+         */
+        @Override
+        final void writeField(Object value) {
+            recordConsumer.startField(fieldName, index);
+            writeRawValue(value);
+            recordConsumer.endField(fieldName, index);
+        }
+
+        private void writeAllFields(MessageOrBuilder pb) {
+            Descriptor messageDescriptor = pb.getDescriptorForType();
+            Descriptors.FileDescriptor.Syntax syntax = messageDescriptor.getFile().getSyntax();
+
+            if (Descriptors.FileDescriptor.Syntax.PROTO2.equals(syntax)) {
+                //returns changed fields with values. Map is ordered by id.
+                Map<FieldDescriptor, Object> changedPbFields = pb.getAllFields();
+
+                for (Map.Entry<FieldDescriptor, Object> entry : changedPbFields.entrySet()) {
+                    FieldDescriptor fieldDescriptor = entry.getKey();
+
+                    if (fieldDescriptor.isExtension()) {
+                        // Field index of an extension field might overlap with a base field.
+                        throw new UnsupportedOperationException(
+                                "Cannot convert Protobuf message with extension field(s)");
+                    }
+
+                    int fieldIndex = fieldDescriptor.getIndex();
+                    fieldWriters[fieldIndex].writeField(entry.getValue());
+                }
+            } else if (Descriptors.FileDescriptor.Syntax.PROTO3.equals(syntax)) {
+                List<FieldDescriptor> fieldDescriptors = messageDescriptor.getFields();
+                for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
+                    FieldDescriptor.Type type = fieldDescriptor.getType();
+
+                    //For a field in a oneOf that isn't set don't write anything
+                    if (fieldDescriptor.getContainingOneof() != null && !pb.hasField(fieldDescriptor)) {
+                        continue;
+                    }
+
+                    if (!fieldDescriptor.isRepeated() && FieldDescriptor.Type.MESSAGE.equals(type) && !pb.hasField(
+                            fieldDescriptor)) {
+                        continue;
+                    }
+                    int fieldIndex = fieldDescriptor.getIndex();
+                    FieldWriter fieldWriter = fieldWriters[fieldIndex];
+                    fieldWriter.writeField(pb.getField(fieldDescriptor));
+                }
+            }
+        }
+    }
+
+    class ArrayWriter extends FieldWriter {
+        final FieldWriter fieldWriter;
+
+        ArrayWriter(FieldWriter fieldWriter) {
+            this.fieldWriter = fieldWriter;
+        }
+
+        @Override
+        final void writeRawValue(Object value) {
+            throw new UnsupportedOperationException("Array has no raw value");
+        }
+
+        @Override
+        final void writeField(Object value) {
+            List<?> list = (List<?>) value;
+            if (list.isEmpty()) {
+                return;
+            }
+
+            recordConsumer.startField(fieldName, index);
+            recordConsumer.startGroup();
+
+            recordConsumer.startField("list", 0); // This is the wrapper group for the array field
+            for (Object listEntry : list) {
+                recordConsumer.startGroup();
+                recordConsumer.startField("element", 0); // This is the mandatory inner field
+
+                fieldWriter.writeRawValue(listEntry);
+
+                recordConsumer.endField("element", 0);
+                recordConsumer.endGroup();
+            }
+            recordConsumer.endField("list", 0);
+
+            recordConsumer.endGroup();
+            recordConsumer.endField(fieldName, index);
+        }
+    }
+
+    /**
+     * The RepeatedWriter is used to write collections (lists and maps) using the old style (without LIST and MAP
+     * wrappers).
+     */
+    class RepeatedWriter extends FieldWriter {
+        final FieldWriter fieldWriter;
+
+        RepeatedWriter(FieldWriter fieldWriter) {
+            this.fieldWriter = fieldWriter;
+        }
+
+        @Override
+        final void writeRawValue(Object value) {
+            throw new UnsupportedOperationException("Array has no raw value");
+        }
+
+        @Override
+        final void writeField(Object value) {
+            List<?> list = (List<?>) value;
+            if (list.isEmpty()) {
+                return;
+            }
+
+            recordConsumer.startField(fieldName, index);
+
+            for (Object listEntry : list) {
+                fieldWriter.writeRawValue(listEntry);
+            }
+
+            recordConsumer.endField(fieldName, index);
+        }
+    }
+
+    class StringWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            Binary binaryString = Binary.fromString((String) value);
+            recordConsumer.addBinary(binaryString);
+        }
+    }
+
+    class IntWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.addInteger((Integer) value);
+        }
+    }
+
+    class LongWriter extends FieldWriter {
+
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.addLong((Long) value);
+        }
+    }
+
+    class MapWriter extends FieldWriter {
+
+        private final FieldWriter keyWriter;
+        private final FieldWriter valueWriter;
+
+        public MapWriter(FieldWriter keyWriter, FieldWriter valueWriter) {
+            super();
+            this.keyWriter = keyWriter;
+            this.valueWriter = valueWriter;
+        }
+
+        @Override
+        final void writeRawValue(Object value) {
+            Collection<Message> collection = (Collection<Message>) value;
+            if (collection.isEmpty()) {
+                return;
+            }
+            recordConsumer.startField(fieldName, index);
+            recordConsumer.startGroup();
+
+            recordConsumer.startField("key_value", 0); // This is the wrapper group for the map field
+            for (Message msg : collection) {
+                recordConsumer.startGroup();
+
+                final Descriptor descriptorForType = msg.getDescriptorForType();
+                final FieldDescriptor keyDesc = descriptorForType.findFieldByName("key");
+                final FieldDescriptor valueDesc = descriptorForType.findFieldByName("value");
+
+                keyWriter.writeField(msg.getField(keyDesc));
+                valueWriter.writeField(msg.getField(valueDesc));
+
+                recordConsumer.endGroup();
+            }
+
+            recordConsumer.endField("key_value", 0);
+
+            recordConsumer.endGroup();
+            recordConsumer.endField(fieldName, index);
+        }
+    }
+
+    class FloatWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.addFloat((Float) value);
+        }
+    }
+
+    class DoubleWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.addDouble((Double) value);
+        }
+    }
+
+    class EnumWriter extends FieldWriter {
+        Map<String, Integer> enumNameNumberPairs;
+
+        public EnumWriter(Descriptors.EnumDescriptor enumType) {
+            if (protoEnumBookKeeper.containsKey(enumType.getFullName())) {
+                enumNameNumberPairs = protoEnumBookKeeper.get(enumType.getFullName());
+            } else {
+                enumNameNumberPairs = new HashMap<>();
+                protoEnumBookKeeper.put(enumType.getFullName(), enumNameNumberPairs);
+            }
+        }
+
+        @Override
+        final void writeRawValue(Object value) {
+            Descriptors.EnumValueDescriptor enumValueDesc = (Descriptors.EnumValueDescriptor) value;
+            Binary binary = Binary.fromString(enumValueDesc.getName());
+            recordConsumer.addBinary(binary);
+            enumNameNumberPairs.putIfAbsent(enumValueDesc.getName(), enumValueDesc.getNumber());
+        }
+    }
+
+    class BooleanWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            recordConsumer.addBoolean((Boolean) value);
+        }
+    }
+
+    class BinaryWriter extends FieldWriter {
+        @Override
+        final void writeRawValue(Object value) {
+            ByteString byteString = (ByteString) value;
+            Binary binary = Binary.fromConstantByteArray(byteString.toByteArray());
+            recordConsumer.addBinary(binary);
+        }
+    }
+}
+

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufParquetWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufParquetWriter.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.format.parquet;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+
+/**
+ * ParquetWriter for protobuf messages with descriptor.
+ */
+public class ProtobufParquetWriter<T extends MessageOrBuilder> extends ParquetWriter<T> {
+    @Deprecated
+    public ProtobufParquetWriter(Path file, Class<? extends Message> protoMessage,
+                                 CompressionCodecName compressionCodecName, int blockSize,
+                                 int pageSize) throws IOException {
+        super(file, new ProtobufDescriptorWriteSupport(protoMessage),
+                compressionCodecName, blockSize, pageSize);
+    }
+
+    @Deprecated
+    public ProtobufParquetWriter(Path file, Class<? extends Message> protoMessage,
+                                 CompressionCodecName compressionCodecName, int blockSize,
+                                 int pageSize, boolean enableDictionary, boolean validating) throws IOException {
+        super(file, new ProtobufDescriptorWriteSupport(protoMessage),
+                compressionCodecName, blockSize, pageSize, enableDictionary, validating);
+    }
+
+    @Deprecated
+    public ProtobufParquetWriter(Path file, Class<? extends Message> protoMessage) throws IOException {
+        this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
+                DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
+    }
+
+    public static <T> Builder<T> builder(Path file) {
+        return new Builder<T>(file);
+    }
+
+    public static <T> Builder<T> builder(OutputFile file) {
+        return new Builder<T>(file);
+    }
+
+    private static <T extends MessageOrBuilder> WriteSupport<T> writeSupport(Descriptors.Descriptor descriptor) {
+        return new ProtobufDescriptorWriteSupport<>(descriptor);
+    }
+
+    /**
+     * Builder for ProtobufParquetWriter.
+     */
+    public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
+        Descriptors.Descriptor descriptor = null;
+
+        private Builder(Path file) {
+            super(file);
+        }
+
+        private Builder(OutputFile file) {
+            super(file);
+        }
+
+        protected Builder<T> self() {
+            return this;
+        }
+
+        public Builder<T> withDescriptor(Descriptors.Descriptor descriptor) {
+            this.descriptor = descriptor;
+            return this;
+        }
+
+        protected WriteSupport<T> getWriteSupport(Configuration conf) {
+            return (WriteSupport<T>) ProtobufParquetWriter.writeSupport(descriptor);
+        }
+    }
+}

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufSchemaConverter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/ProtobufSchemaConverter.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.format.parquet;
+
+import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.listType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.mapType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
+import com.google.protobuf.Message;
+import com.twitter.elephantbird.util.Protobufs;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Types.Builder;
+import org.apache.parquet.schema.Types.GroupBuilder;
+
+/**
+ * Converts a Protobuf schema to a Parquet schema.
+ */
+@Slf4j
+public class ProtobufSchemaConverter {
+    private final boolean parquetSpecsCompliant;
+
+    public ProtobufSchemaConverter() {
+        this(false);
+    }
+
+    /**
+     * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+     * @param parquetSpecsCompliant   If set to false, the parquet schema generated will be using the old
+     *                                schema style (prior to PARQUET-968) to provide backward-compatibility
+     *                                but which does not use LIST and MAP wrappers around collections as required
+     *                                by the parquet specifications. If set to true, specs compliant schemas are used.
+     */
+    public ProtobufSchemaConverter(boolean parquetSpecsCompliant) {
+        this.parquetSpecsCompliant = parquetSpecsCompliant;
+    }
+
+    public MessageType convert(Descriptors.Descriptor descriptor) {
+        MessageType messageType =
+                convertFields(Types.buildMessage(), descriptor.getFields())
+                        .named(descriptor.getFullName());
+        log.debug("Converter info:\n " + descriptor.toProto() + " was converted to \n" + messageType);
+        return messageType;
+    }
+
+    public MessageType convert(Class<? extends Message> protobufClass) {
+        log.debug("Converting protocol buffer class \"" + protobufClass + "\" to parquet schema.");
+        Descriptors.Descriptor descriptor = Protobufs.getMessageDescriptor(protobufClass);
+        return convert(descriptor);
+    }
+
+    /* Iterates over list of fields. **/
+    private <T> Types.GroupBuilder<T> convertFields(Types.GroupBuilder<T> groupBuilder,
+                                                    List<Descriptors.FieldDescriptor> fieldDescriptors) {
+        for (Descriptors.FieldDescriptor fieldDescriptor : fieldDescriptors) {
+            groupBuilder =
+                    addField(fieldDescriptor, groupBuilder)
+                            .id(fieldDescriptor.getNumber())
+                            .named(fieldDescriptor.getName());
+        }
+        return groupBuilder;
+    }
+
+    private Type.Repetition getRepetition(Descriptors.FieldDescriptor descriptor) {
+        if (descriptor.isRequired()) {
+            return Type.Repetition.REQUIRED;
+        } else if (descriptor.isRepeated()) {
+            return Type.Repetition.REPEATED;
+        } else {
+            return Type.Repetition.OPTIONAL;
+        }
+    }
+
+    private <T> Builder<? extends Builder<?, Types.GroupBuilder<T>>, Types.GroupBuilder<T>> addField(
+            FieldDescriptor descriptor, final GroupBuilder<T> builder) {
+        if (descriptor.getJavaType() == JavaType.MESSAGE) {
+            return addMessageField(descriptor, builder);
+        }
+
+        ParquetType parquetType = getParquetType(descriptor);
+        if (descriptor.isRepeated() && parquetSpecsCompliant) {
+            // the old schema style did not include the LIST wrapper around repeated fields
+            return addRepeatedPrimitive(parquetType.primitiveType, parquetType.logicalTypeAnnotation, builder);
+        }
+
+        return builder.primitive(parquetType.primitiveType, getRepetition(descriptor))
+                .as(parquetType.logicalTypeAnnotation);
+    }
+
+    private <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addRepeatedPrimitive(
+            PrimitiveTypeName primitiveType,
+            LogicalTypeAnnotation logicalTypeAnnotation,
+            final GroupBuilder<T> builder) {
+        return builder
+                .group(Type.Repetition.OPTIONAL).as(listType())
+                .group(Type.Repetition.REPEATED)
+                .primitive(primitiveType, Type.Repetition.REQUIRED).as(logicalTypeAnnotation)
+                .named("element")
+                .named("list");
+    }
+
+    private <T> GroupBuilder<GroupBuilder<T>> addRepeatedMessage(FieldDescriptor descriptor, GroupBuilder<T> builder) {
+        GroupBuilder<GroupBuilder<GroupBuilder<GroupBuilder<T>>>> result =
+                builder
+                        .group(Type.Repetition.OPTIONAL).as(listType())
+                        .group(Type.Repetition.REPEATED)
+                        .group(Type.Repetition.OPTIONAL);
+
+        convertFields(result, descriptor.getMessageType().getFields());
+
+        return result.named("element").named("list");
+    }
+
+    private <T> GroupBuilder<GroupBuilder<T>> addMessageField(FieldDescriptor descriptor,
+                                                              final GroupBuilder<T> builder) {
+        if (descriptor.isMapField() && parquetSpecsCompliant) {
+            // the old schema style did not include the MAP wrapper around map groups
+            return addMapField(descriptor, builder);
+        }
+        if (descriptor.isRepeated() && parquetSpecsCompliant) {
+            // the old schema style did not include the LIST wrapper around repeated messages
+            return addRepeatedMessage(descriptor, builder);
+        }
+
+        // Plain message
+        GroupBuilder<GroupBuilder<T>> group = builder.group(getRepetition(descriptor));
+        convertFields(group, descriptor.getMessageType().getFields());
+        return group;
+    }
+
+    private <T> GroupBuilder<GroupBuilder<T>> addMapField(FieldDescriptor descriptor, final GroupBuilder<T> builder) {
+        List<FieldDescriptor> fields = descriptor.getMessageType().getFields();
+        if (fields.size() != 2) {
+            throw new UnsupportedOperationException("Expected two fields for the map (key/value), but got: " + fields);
+        }
+
+        ParquetType mapKeyParquetType = getParquetType(fields.get(0));
+
+        GroupBuilder<GroupBuilder<GroupBuilder<T>>> group = builder
+                .group(Type.Repetition.OPTIONAL).as(mapType()) // only optional maps are allowed in Proto3
+                .group(Type.Repetition.REPEATED) // key_value wrapper
+                .primitive(mapKeyParquetType.primitiveType, Type.Repetition.REQUIRED)
+                .as(mapKeyParquetType.logicalTypeAnnotation).named("key");
+
+        return addField(fields.get(1), group).named("value")
+                .named("key_value");
+    }
+
+    private ParquetType getParquetType(FieldDescriptor fieldDescriptor) {
+
+        JavaType javaType = fieldDescriptor.getJavaType();
+        switch (javaType) {
+            case INT:
+                return ParquetType.of(INT32);
+            case LONG:
+                return ParquetType.of(INT64);
+            case DOUBLE:
+                return ParquetType.of(DOUBLE);
+            case BOOLEAN:
+                return ParquetType.of(BOOLEAN);
+            case FLOAT:
+                return ParquetType.of(FLOAT);
+            case STRING:
+                return ParquetType.of(BINARY, stringType());
+            case ENUM:
+                return ParquetType.of(BINARY, enumType());
+            case BYTE_STRING:
+                return ParquetType.of(BINARY);
+            default:
+                throw new UnsupportedOperationException("Cannot convert Protocol Buffer: unknown type " + javaType);
+        }
+    }
+
+    /**
+     * ParquetType.
+     */
+    private static class ParquetType {
+        PrimitiveTypeName primitiveType;
+        LogicalTypeAnnotation logicalTypeAnnotation;
+
+        private ParquetType(PrimitiveTypeName primitiveType, LogicalTypeAnnotation logicalTypeAnnotation) {
+            this.primitiveType = primitiveType;
+            this.logicalTypeAnnotation = logicalTypeAnnotation;
+        }
+
+        public static ParquetType of(PrimitiveTypeName primitiveType, LogicalTypeAnnotation logicalTypeAnnotation) {
+            return new ParquetType(primitiveType, logicalTypeAnnotation);
+        }
+
+        public static ParquetType of(PrimitiveTypeName primitiveType) {
+            return of(primitiveType, null);
+        }
+    }
+
+
+}

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/package-info.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/parquet/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.format.parquet;

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.protobuf.ProtobufData;
@@ -39,9 +40,11 @@ import org.apache.pulsar.functions.api.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * avro util.
  */
+@Slf4j
 public class AvroRecordUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AvroRecordUtil.class);
@@ -160,6 +163,30 @@ public class AvroRecordUtil {
                                                                              Schema rootAvroSchema) {
         return convertGenericRecord(recordValue, rootAvroSchema, false);
     }
+//    public static org.apache.avro.generic.GenericRecord convertGenericRecord(DynamicMessage recordValue,
+//                                                                             Schema rootAvroSchema) {
+//        org.apache.avro.generic.GenericRecord recordHolder = new GenericData.Record(rootAvroSchema);
+//        for (Schema.Field field : rootAvroSchema.getFields()) {
+//            String fieldName = field.name();
+//            Object valueField = recordValue.getField(recordValue.getDescriptorForType().findFieldByName(fieldName));
+//            log.info("field: {}, schema: {}, value: {}, value type: {}",
+//                    field, recordValue.getDescriptorForType().findFieldByName(fieldName),
+//                    valueField, valueField.getClass().getName());
+//            if (valueField instanceof DynamicMessage) {
+//                Schema subSchema = field.schema();
+//                if (field.schema().isUnion()) {
+//                    subSchema = field.schema().getTypes().stream()
+//                            .filter(schema -> schema.getType().equals(Schema.Type.RECORD))
+//                            .findFirst()
+//                            .get();
+//                }
+//                valueField = convertGenericRecord((DynamicMessage) valueField, subSchema);
+//            }
+//            recordHolder.put(fieldName, valueField);
+//        }
+//        log.info("convert DynamicMessage to GenericRecord: {}", recordHolder);
+//        return recordHolder;
+//    }
     public static org.apache.avro.generic.GenericRecord convertGenericRecord(GenericRecord recordValue,
                                                                              Schema rootAvroSchema,
                                                                              boolean useMetadata) {
@@ -168,7 +195,6 @@ public class AvroRecordUtil {
             Schema.Field field1 = rootAvroSchema.getField(field.getName());
             Object valueField = readValue(recordValue, field);
             if (valueField instanceof GenericRecord) {
-
                 Schema subSchema = field1.schema();
                 if (field1.schema().isUnion()) {
                     subSchema = field1.schema().getTypes().stream()
@@ -178,6 +204,16 @@ public class AvroRecordUtil {
                 }
                 valueField = convertGenericRecord((GenericRecord) valueField, subSchema);
             }
+//            else if (valueField instanceof DynamicMessage) {
+//                Schema subSchema = field1.schema();
+//                if (field1.schema().isUnion()) {
+//                    subSchema = field1.schema().getTypes().stream()
+//                            .filter(schema -> schema.getType().equals(Schema.Type.RECORD))
+//                            .findFirst()
+//                            .get();
+//                }
+//                valueField = convertGenericRecord((DynamicMessage) valueField, subSchema);
+//            }
             recordHolder.put(field.getName(), valueField);
         }
         return recordHolder;

--- a/src/main/proto/ProtobufMessageMetadata.proto
+++ b/src/main/proto/ProtobufMessageMetadata.proto
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "org.apache.pulsar.io.jcloud.format.parquet.proto";
+option java_outer_classname = "Metadata";
+
+message PulsarIOCSCProtobufMessageMetadata {
+  map<string, string> properties = 1;
+  string schema_version = 2;
+  string message_id = 3;
+}
+

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
@@ -20,8 +20,10 @@ package org.apache.pulsar.io.jcloud.format;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.google.protobuf.DynamicMessage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.SeekableByteArrayInput;
@@ -84,5 +86,19 @@ public class AvroFormatTest extends FormatTestBase {
         final SeekableByteArrayInput input = new SeekableByteArrayInput(byteSource.read());
         final DataFileReader<Object> objects = new DataFileReader<>(input, datumReader);
         return (org.apache.avro.generic.GenericRecord) objects.next();
+    }
+
+    @Override
+    public DynamicMessage getDynamicMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getJSONMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void testProtobufNativeRecordWriter() throws Exception {
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.format;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.DynamicMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * json format test.
+ */
+public class JsonFormatTest extends FormatTestBase {
+    private static final ThreadLocal<ObjectMapper> JSON_MAPPER = ThreadLocal.withInitial(() -> {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    });
+
+    private static final Logger log = LoggerFactory.getLogger(JsonFormatTest.class);
+    private JsonFormat format = new JsonFormat();
+
+    @Override
+    public Format<GenericRecord> getFormat() {
+        return format;
+    }
+
+    @Override
+    public String expectedFormatExtension() {
+        return ".json";
+    }
+
+    @Override
+    protected boolean supportMetadata() {
+        return true;
+    }
+
+    public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
+                                                                          Message<GenericRecord> msg) throws Exception {
+        return null;
+    }
+
+    @Override
+    public DynamicMessage getDynamicMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Consumer<Message<GenericRecord>> getMessageConsumer(TopicName topic) {
+        return msg -> {
+            try {
+                Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
+                initSchema(schema);
+                Map<String, Object> formatGeneratedRecord = getJSONMessage(topic, msg);
+                assertEquals(msg.getValue(), formatGeneratedRecord);
+            } catch (Exception e) {
+                log.error("formatter handle message is fail", e);
+                Assert.fail();
+            }
+        };
+    }
+
+    @Override
+    public Consumer<Message<GenericRecord>> getJSONMessageConsumer(TopicName topic) {
+        return msg -> {
+            try {
+                Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
+                initSchema(schema);
+                Map<String, Object> message = getJSONMessage(topic, msg);
+                assertEquals(msg.getValue(), message);
+            } catch (Exception e) {
+                log.error("formatter handle message is fail", e);
+                Assert.fail();
+            }
+        };
+    }
+
+    @Override
+    public Map<String, Object> getJSONMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        Record<GenericRecord> mockRecord = mock(Record.class);
+        Schema<GenericRecord> mockSchema = mock(Schema.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
+        when(mockRecord.getValue()).thenReturn(msg.getValue());
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        when(mockRecord.getSchema()).thenReturn(mockSchema);
+
+        List<Record<GenericRecord>> records = new ArrayList<>();
+        records.add(mockRecord);
+
+        ByteSource byteSource = getFormat().recordWriter(records.listIterator());
+        Map<String, Object> record = JSON_MAPPER.get().readValue(byteSource.read(), Map.class);
+        return record;
+    }
+
+    @Override
+    public void testProtobufNativeRecordWriter() throws Exception {
+    }
+
+    private void assertEquals(GenericRecord msgValue, Map<String, Object> record) {
+        List<Field> fields = msgValue.getFields();
+        for (Field field : fields) {
+            String name = field.getName();
+            Object value = msgValue.getField(field);
+            if (!(value instanceof GenericRecord)) {
+                Assert.assertEquals(record.get(name), value);
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/ParquetFormatTest.java
@@ -20,18 +20,23 @@ package org.apache.pulsar.io.jcloud.format;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.google.protobuf.DynamicMessage;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.proto.ProtoParquetReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.schema.proto.Test;
 import org.apache.pulsar.io.jcloud.support.ParquetInputFile;
 import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
 import org.slf4j.Logger;
@@ -59,7 +64,7 @@ public class ParquetFormatTest extends FormatTestBase {
 
     @Override
     protected boolean supportMetadata() {
-        return true;
+        return false;
     }
 
     public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
@@ -91,5 +96,41 @@ public class ParquetFormatTest extends FormatTestBase {
 
         return record;
 
+    }
+
+    @Override
+    public DynamicMessage getDynamicMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        Record<GenericRecord> mockRecord = mock(Record.class);
+        Schema<GenericRecord> mockSchema = mock(Schema.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        when(mockRecord.getSchema()).thenReturn(mockSchema);
+        when(mockRecord.getValue()).thenReturn(msg.getValue());
+
+        List<Record<GenericRecord>> records = new ArrayList<>();
+        records.add(mockRecord);
+
+        ByteSource byteSource = getFormat().recordWriter(records.listIterator());
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        stream.write(byteSource.read());
+        ParquetInputFile file = new ParquetInputFile("tmp.parquet", stream);
+
+        Configuration configuration = new Configuration();
+        configuration.set("parquet.proto.class", Test.TestMessage.class.getName());
+
+        ParquetReader<Test.TestMessage.Builder> reader =
+                ProtoParquetReader.<Test.TestMessage.Builder>builder(file).withConf(configuration).build();
+
+        Test.TestMessage.Builder record = reader.read();
+
+        return DynamicMessage.newBuilder(record.build()).build();
+    }
+
+    @Override
+    public Map<String, Object> getJSONMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        return null;
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/schema/ProtobufNativeSchemaTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/schema/ProtobufNativeSchemaTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.schema;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import com.google.common.collect.Lists;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.client.impl.schema.generic.GenericProtobufNativeRecord;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
+import org.apache.pulsar.io.jcloud.format.ParquetFormat;
+import org.junit.Test;
+
+/**
+ * ProtobufNativeSchema tests.
+ */
+public class ProtobufNativeSchemaTest {
+    @Test
+    public void parquetTest() {
+        Record<GenericRecord> r = mock(Record.class);
+        GenericProtobufNativeRecord record = mock(GenericProtobufNativeRecord.class);
+        org.apache.pulsar.client.api.Schema<GenericRecord> schema = mock(ProtobufNativeSchema.class);
+        SchemaInfo schemaInfo = mock(SchemaInfoImpl.class);
+        Descriptors.Descriptor descriptor = org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.getDescriptor();
+        org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.Builder msg =
+                org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.newBuilder();
+        msg.setStringField("test");
+        DynamicMessage dynamicMessage = DynamicMessage.newBuilder(msg.build()).build();
+        when(record.getNativeObject()).thenReturn(dynamicMessage);
+        when(record.getProtobufRecord()).thenReturn(dynamicMessage);
+        when(record.getSchemaType()).thenReturn(SchemaType.PROTOBUF_NATIVE);
+        when(schema.getSchemaInfo()).thenReturn(schemaInfo);
+        when(schema.getNativeSchema()).thenReturn(Optional.of(descriptor));
+        when(schemaInfo.getSchema()).thenReturn(ProtobufNativeSchemaUtils.serialize(descriptor));
+        when(schemaInfo.getType()).thenReturn(SchemaType.PROTOBUF_NATIVE);
+        when(r.getValue()).thenReturn(record);
+        try {
+            ParquetFormat parquetFormat = new ParquetFormat();
+            parquetFormat.initSchema(schema);
+            ByteBuffer bytes = parquetFormat.recordWriterBuf(Lists.newArrayList(r).iterator());
+            assertNotEquals(0, bytes.array().length);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void parquetWithMetadataTest() {
+        Record<GenericRecord> r = mock(Record.class);
+        GenericProtobufNativeRecord record = mock(GenericProtobufNativeRecord.class);
+        org.apache.pulsar.client.api.Schema<GenericRecord> schema = mock(ProtobufNativeSchema.class);
+        SchemaInfo schemaInfo = mock(SchemaInfoImpl.class);
+        Descriptors.Descriptor descriptor =
+                org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.getDescriptor();
+        org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.Builder msg =
+                org.apache.pulsar.io.jcloud.schema.proto.Test.TestMessage.newBuilder();
+        msg.setStringField("test");
+        DynamicMessage dynamicMessage = DynamicMessage.newBuilder(msg.build()).build();
+        when(record.getNativeObject()).thenReturn(dynamicMessage);
+        when(record.getProtobufRecord()).thenReturn(dynamicMessage);
+        when(record.getSchemaType()).thenReturn(SchemaType.PROTOBUF_NATIVE);
+        when(schema.getSchemaInfo()).thenReturn(schemaInfo);
+        when(schema.getNativeSchema()).thenReturn(Optional.of(descriptor));
+        when(schemaInfo.getSchema()).thenReturn(ProtobufNativeSchemaUtils.serialize(descriptor));
+        when(schemaInfo.getType()).thenReturn(SchemaType.PROTOBUF_NATIVE);
+        when(r.getValue()).thenReturn(record);
+
+        Message m = mock(Message.class);
+        when(r.getMessage()).thenReturn(Optional.of(m));
+        when(m.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        when(m.getSchemaVersion()).thenReturn(new byte[] { 1 });
+        when(m.getPublishTime()).thenReturn(System.currentTimeMillis());
+        when(m.getEventTime()).thenReturn(System.currentTimeMillis());
+        when(m.getSequenceId()).thenReturn(1L);
+
+        BlobStoreAbstractConfig config = mock(BlobStoreAbstractConfig.class);
+        when(config.isWithMetadata()).thenReturn(true);
+        try {
+            ParquetFormat parquetFormat = new ParquetFormat();
+            parquetFormat.configure(config);
+            parquetFormat.initSchema(schema);
+            ByteBuffer bytes = parquetFormat.recordWriterBuf(Lists.newArrayList(r).iterator());
+            assertNotEquals(0, bytes.array().length);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    }
+}

--- a/src/test/proto/ExternalTest.proto
+++ b/src/test/proto/ExternalTest.proto
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+package proto.external;
+
+option java_package = "org.apache.pulsar.io.jcloud.schema.proto";
+option java_outer_classname = "ExternalTest";
+
+message ExternalMessage {
+    string stringField = 1;
+    double doubleField = 2;
+}

--- a/src/test/proto/Test.proto
+++ b/src/test/proto/Test.proto
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+package proto;
+
+import "ExternalTest.proto";
+
+option java_package = "org.apache.pulsar.io.jcloud.schema.proto";
+option java_outer_classname = "Test";
+
+enum TestEnum {
+  SHARED = 0;
+  FAILOVER = 1;
+}
+
+message SubMessage {
+  string foo = 1;
+  double bar = 2;
+  message NestedMessage {
+    string url = 1;
+    string title = 2;
+    repeated string snippets = 3;
+  }
+}
+
+message TestMessage {
+  string stringField = 1;
+  double doubleField = 2;
+  int32 intField = 6;
+  TestEnum testEnum = 4;
+  SubMessage nestedField = 5;
+  repeated string repeatedField = 10;
+  proto.external.ExternalMessage externalMessage = 11;
+}


### PR DESCRIPTION
Fixes #268

### Motivation

When write protobuf_native messages into parquet format, it is suggested to use https://github.com/apache/parquet-mr/tree/master/parquet-protobuf, but not using AVRO as an intermediate format. Also, AVRO do not fully support lossless transform with PROTOBUF, so with previous implementation, the nested or complex PROTOBUF schema cannot be converted to AVRO successfully. 

### Modifications

- Add Protobuf Parquet writer (due to known issue https://issues.apache.org/jira/browse/PARQUET-1020) with DynamicMessage support
- Add MessageMetadata proto
- Add PROTOBUF_NATIVE tests

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
