### PR TITLE
[#458][sink] Fix multiple topics in the same output blob

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/format/Format.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/Format.java
@@ -26,7 +26,7 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
 
 /**
- * record format.
+ * output record format.
  */
 public interface Format<T> {
     /**


### PR DESCRIPTION
Fixes #458 

### Motivation


If the connector was reading from multiple topics, the records would end up getting mixed. This is because for each batch the sink would only look at the first record to determine which topic it came from.

### Modifications

Divide records of the batch by topic, then for each topic verify the schema and upload to the correct blob for the respective topic. 
Also had to make a small change to when the partitioning timestamp is created, so that all records in one batch will end up having the same timestamp, irrespective of their topic.

### Verifying this change

* Had to manually test this change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API: (yes / *no*)
  - The schema: (yes / *no* / don't know)
  - The default values of configurations: (yes / *no*)
  - The wire protocol: (yes / *no*)
  - The rest endpoints: (yes / *no*)
  - The admin cli options: (yes / *no*)
  - Anything that affects deployment: (yes / *no* / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (*not applicable* / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why? Already exists, just fixed
