### PR TITLE
Support for KeyValue schema

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -99,6 +99,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
             case JSON:
             case PROTOBUF:
             case PROTOBUF_NATIVE:
+            case KEY_VALUE:
                 return true;
             default:
                 return false;

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -34,7 +34,9 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
@@ -85,6 +87,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             case PROTOBUF_NATIVE:
             case BYTES:
             case STRING:
+            case KEY_VALUE:
                 return true;
             default:
                 return false;
@@ -97,8 +100,9 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         while (record.hasNext()) {
             Record<GenericRecord> next = record.next();
             GenericRecord val = next.getValue();
-            log.debug("next record {} schema {} val {}", next, next.getSchema(), val);
-            Map<String, Object> writeValue = convertRecordToObject(next.getValue());
+            final Schema<GenericRecord> schema = next.getSchema();
+            log.debug("next record {} schema {} val {}", next, schema, val);
+            Map<String, Object> writeValue = convertRecordToObject(next.getValue(), schema);
             if (useMetadata) {
                 writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY,
                         MetadataUtil.extractedMetadata(next, useHumanReadableMessageId, useHumanReadableSchemaVersion));
@@ -109,7 +113,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         return ByteBuffer.wrap(stringBuilder.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    private Map<String, Object> convertRecordToObject(GenericRecord record) throws IOException {
+    private Map<String, Object> convertRecordToObject(GenericRecord record, Schema<?> schema) throws IOException {
         if (record.getSchemaType().isStruct()) {
             switch (record.getSchemaType()) {
                 case AVRO:
@@ -122,7 +126,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
                         String name = field.getName();
                         Object value = record.getField(field);
                         if (value instanceof GenericRecord) {
-                            value = convertRecordToObject((GenericRecord) value);
+                            value = convertRecordToObject((GenericRecord) value, schema);
                         }
                         result.put(name, value);
                     }
@@ -142,6 +146,20 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             return JSON_MAPPER.get().readValue((String) record.getNativeObject(), TYPEREF);
         } else if (record.getSchemaType() == SchemaType.BYTES) {
             return JSON_MAPPER.get().readValue((byte[]) record.getNativeObject(), TYPEREF);
+        } else if (record.getSchemaType() == SchemaType.KEY_VALUE) {
+            Map<String, Object> jsonKeyValue = new LinkedHashMap<>(2);
+            KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) schema;
+            org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject> keyValue =
+                    (org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject>) record.getNativeObject();
+            if (keyValue.getKey() != null) {
+                jsonKeyValue.put("key", convertRecordToObject((GenericRecord) keyValue.getKey(),
+                        keyValueSchema.getKeySchema()));
+            }
+            if (keyValue.getValue() != null) {
+                jsonKeyValue.put("value", convertRecordToObject((GenericRecord) keyValue.getValue(),
+                        keyValueSchema.getValueSchema()));
+            }
+            return jsonKeyValue;
         }
         throw new UnsupportedOperationException("Unsupported value schemaType=" + record.getSchemaType());
     }

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -199,6 +199,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
             case JSON:
             case PROTOBUF:
             case PROTOBUF_NATIVE:
+            case KEY_VALUE:
                 return true;
             default:
                 return false;
@@ -232,6 +233,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
             while (records.hasNext()) {
                 final Record<GenericRecord> next = records.next();
                 GenericRecord genericRecord = next.getValue();
+                final org.apache.pulsar.client.api.Schema<GenericRecord> schema = next.getSchema();
                 if (genericRecord.getSchemaType() == SchemaType.BYTES
                         && internalSchema.getSchemaInfo().getType() == SchemaType.PROTOBUF_NATIVE) {
                     genericRecord = internalSchema.decode((byte[]) next.getValue().getNativeObject());

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -233,7 +233,6 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
             while (records.hasNext()) {
                 final Record<GenericRecord> next = records.next();
                 GenericRecord genericRecord = next.getValue();
-                final org.apache.pulsar.client.api.Schema<GenericRecord> schema = next.getSchema();
                 if (genericRecord.getSchemaType() == SchemaType.BYTES
                         && internalSchema.getSchemaInfo().getType() == SchemaType.PROTOBUF_NATIVE) {
                     genericRecord = internalSchema.decode((byte[]) next.getValue().getNativeObject());

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
@@ -35,7 +35,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.protobuf.ProtobufData;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -217,21 +216,6 @@ public class AvroRecordUtil {
     public static org.apache.avro.generic.GenericRecord convertGenericRecord(GenericRecord recordValue,
                                                                              Schema rootAvroSchema) {
         org.apache.avro.generic.GenericRecord recordHolder = new GenericData.Record(rootAvroSchema);
-        if (recordValue.getSchemaType() == SchemaType.KEY_VALUE) {
-            org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject> keyValue =
-                    (org.apache.pulsar.common.schema.KeyValue<GenericObject, GenericObject>)
-                            recordValue.getNativeObject();
-            if (keyValue.getKey() != null) {
-                final GenericRecord recordKeyRecord = (GenericRecord) keyValue.getKey();
-                recordHolder.put("key", convertGenericRecord(recordKeyRecord,
-                        rootAvroSchema.getField("key").schema()));
-            }
-            if (keyValue.getValue() != null) {
-                final GenericRecord recordValueRecord = (GenericRecord) keyValue.getValue();
-                recordHolder.put("key", convertGenericRecord(recordValueRecord,
-                        rootAvroSchema.getField("value").schema()));
-            }
-        }
         for (org.apache.pulsar.client.api.schema.Field field : recordValue.getFields()) {
             Schema.Field field1 = rootAvroSchema.getField(field.getName());
             Object valueField = readValue(recordValue, field);

--- a/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.io.jcloud.container.PulsarContainer;
 import org.junit.AfterClass;
@@ -177,6 +178,11 @@ public abstract class PulsarTestBase {
                     break;
                 case JSON:
                     producer = (Producer<T>) client.newProducer(Schema.JSON(tClass)).topic(topicName).create();
+                    break;
+                case KEY_VALUE:
+                    final KeyValue kvMessage = (KeyValue) messages.get(0);
+                    producer = (Producer<T>) client.newProducer(Schema.KeyValue(kvMessage.getKey().getClass(),
+                            kvMessage.getValue().getClass())).topic(topicName).create();
                     break;
 
                 default:

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/AvroFormatTest.java
@@ -65,20 +65,20 @@ public class AvroFormatTest extends FormatTestBase {
 
     public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
                                                                           Message<GenericRecord> msg) throws Exception {
+        final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
         Record<GenericRecord> mockRecord = mock(Record.class);
-        Schema<GenericRecord> mockSchema = mock(Schema.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
         when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
         when(mockRecord.getValue()).thenReturn(msg.getValue());
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
         when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
-        when(mockRecord.getSchema()).thenReturn(mockSchema);
+        when(mockRecord.getSchema()).thenReturn(schema);
 
         List<Record<GenericRecord>> records = new ArrayList<>();
         records.add(mockRecord);
 
-        final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
+
         org.apache.avro.Schema avroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         avroSchema = MetadataUtil.setMetadataSchema(avroSchema);
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/BytesFormatTest.java
@@ -80,15 +80,15 @@ public class BytesFormatTest extends FormatTestBase {
 
     public org.apache.avro.generic.GenericRecord getFormatGeneratedRecord(TopicName topicName,
                                                                           Message<GenericRecord> msg) throws Exception {
+        final Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
         Record<GenericRecord> mockRecord = mock(Record.class);
-        Schema<GenericRecord> mockSchema = mock(Schema.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
         when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
         when(mockRecord.getValue()).thenReturn(msg.getValue());
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
         when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
-        when(mockRecord.getSchema()).thenReturn(mockSchema);
+        when(mockRecord.getSchema()).thenReturn(schema);
 
         List<Record<GenericRecord>> records = new ArrayList<>();
         records.add(mockRecord);

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
 import org.apache.pulsar.io.jcloud.PulsarTestBase;
@@ -109,6 +110,30 @@ public abstract class FormatTestBase extends PulsarTestBase {
         );
 
         sendTypedMessages(jsonTopicName.toString(), SchemaType.JSON, testRecords, Optional.empty(), TestRecord.class);
+
+        Consumer<Message<GenericRecord>>
+                handle = getJSONMessageConsumer(jsonTopicName);
+        consumerMessages(jsonTopicName.toString(), Schema.AUTO_CONSUME(), handle, testRecords.size(), 2000);
+    }
+
+
+    @Test
+    public void testKeyValueRecordWriter() throws Exception {
+        KeyValue<TestRecord, TestRecord> kv1 = new KeyValue<>(
+                new TestRecord("key1", 1, null),
+                new TestRecord("value1", 1, null)
+        );
+        KeyValue<TestRecord, TestRecord> kv2 = new KeyValue<>(
+                new TestRecord("key1", 1, new TestRecord.TestSubRecord("aaa")),
+                new TestRecord("value1", 1, new TestRecord.TestSubRecord("aaa"))
+        );
+        List<KeyValue> testRecords = Arrays.asList(
+                kv1,
+                kv2
+        );
+
+        sendTypedMessages(jsonTopicName.toString(), SchemaType.KEY_VALUE,
+                testRecords, Optional.empty(), KeyValue.class);
 
         Consumer<Message<GenericRecord>>
                 handle = getJSONMessageConsumer(jsonTopicName);

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -63,6 +63,8 @@ public abstract class FormatTestBase extends PulsarTestBase {
             TopicName.get("test-parquet-avro" + RandomStringUtils.randomAlphabetic(5));
     private static final TopicName jsonTopicName =
             TopicName.get("test-parquet-json" + RandomStringUtils.randomAlphabetic(5));
+    private static final TopicName kvTopicName =
+            TopicName.get("test-parquet-kv" + RandomStringUtils.randomAlphabetic(5));
     private static final TopicName protobufNativeTopicName =
             TopicName.get("test-parquet-protobuf-native" + RandomStringUtils.randomAlphabetic(5));
 
@@ -73,6 +75,8 @@ public abstract class FormatTestBase extends PulsarTestBase {
                 .build();
         pulsarAdmin.topics().createPartitionedTopic(jsonTopicName.toString(), 1);
         pulsarAdmin.topics().createSubscription(jsonTopicName.toString(), "test", MessageId.earliest);
+        pulsarAdmin.topics().createPartitionedTopic(kvTopicName.toString(), 1);
+        pulsarAdmin.topics().createSubscription(kvTopicName.toString(), "test", MessageId.earliest);
         pulsarAdmin.topics().createPartitionedTopic(avroTopicName.toString(), 1);
         pulsarAdmin.topics().createSubscription(avroTopicName.toString(), "test", MessageId.earliest);
         pulsarAdmin.topics().createPartitionedTopic(protobufNativeTopicName.toString(), 1);
@@ -132,12 +136,12 @@ public abstract class FormatTestBase extends PulsarTestBase {
                 kv2
         );
 
-        sendTypedMessages(jsonTopicName.toString(), SchemaType.KEY_VALUE,
+        sendTypedMessages(kvTopicName.toString(), SchemaType.KEY_VALUE,
                 testRecords, Optional.empty(), KeyValue.class);
 
         Consumer<Message<GenericRecord>>
-                handle = getJSONMessageConsumer(jsonTopicName);
-        consumerMessages(jsonTopicName.toString(), Schema.AUTO_CONSUME(), handle, testRecords.size(), 2000);
+                handle = getJSONMessageConsumer(kvTopicName);
+        consumerMessages(kvTopicName.toString(), Schema.AUTO_CONSUME(), handle, testRecords.size(), 2000);
     }
 
     @Test

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -112,15 +112,15 @@ public class JsonFormatTest extends FormatTestBase {
 
     @Override
     public Map<String, Object> getJSONMessage(TopicName topicName, Message<GenericRecord> msg) throws Exception {
+        Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
         Record<GenericRecord> mockRecord = mock(Record.class);
-        Schema<GenericRecord> mockSchema = mock(Schema.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topicName.toString()));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(0));
         when(mockRecord.getMessage()).thenReturn(Optional.of(msg));
         when(mockRecord.getValue()).thenReturn(msg.getValue());
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topicName, 0)));
         when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
-        when(mockRecord.getSchema()).thenReturn(mockSchema);
+        when(mockRecord.getSchema()).thenReturn(schema);
 
         List<Record<GenericRecord>> records = new ArrayList<>();
         records.add(mockRecord);


### PR DESCRIPTION
### Motivation
KeyValue is not supported in any format.

### Modifications

* Added support for KeyValue schema for all the formats. The output struct has "key" and "value" fields. 
