### PR TITLE
[#14][config] Validate endpoint URI scheme

### DIFF
--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -42,7 +42,7 @@ public class ConnectorConfigTest {
         config.put("secretAccessKey", "aws-s3");
         config.put("bucket", "testbucket");
         config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
+        config.put("endpoint", "https://us-standard");
         config.put("pathPrefix", "pulsar/");
         config.put("formatType", "avro");
         config.put("partitionerType", "default");
@@ -73,7 +73,7 @@ public class ConnectorConfigTest {
         config.put("secretAccessKey", "aws-s3");
         config.put("bucket", "testbucket");
         config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
+        config.put("endpoint", "https://us-standard");
         config.put("formatType", "avro");
         config.put("partitionerType", "time");
         config.put("timePartitionPattern", "yyyy-MM-dd");
@@ -133,7 +133,7 @@ public class ConnectorConfigTest {
         config.put("secretAccessKey", "aws-s3");
         config.put("bucket", "testbucket");
         config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
+        config.put("endpoint", "https://us-standard");
         config.put("formatType", "avro");
         config.put("partitionerType", "default");
         config.put("timePartitionPattern", "yyyy-MM-dd");
@@ -177,12 +177,32 @@ public class ConnectorConfigTest {
     }
 
     @Test
+    public final void throwOnMalformedEndpointTest() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", PROVIDER_AWSS3);
+        config.put("accessKeyId", "aws-s3");
+        config.put("secretAccessKey", "aws-s3");
+        config.put("bucket", "testbucket");
+        config.put("region", "us-east-1");
+        config.put("endpoint", "s3.us-east-1.amazonaws.com"); // no URI scheme
+        config.put("pathPrefix", "pulsar/");
+        config.put("formatType", "avro");
+        config.put("partitionerType", "default");
+        config.put("timePartitionPattern", "yyyy-MM-dd");
+        config.put("timePartitionDuration", "2d");
+        config.put("batchSize", 10);
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> CloudStorageSinkConfig.load(config).validate());
+    }
+
+    @Test
     public final void loadFromMapCredentialFromSecretTest() throws IOException {
         Map<String, Object> config = new HashMap<>();
         config.put("provider", "aws-s3");
         config.put("bucket", "testbucket");
         config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
+        config.put("endpoint", "https://us-standard");
         config.put("formatType", "avro");
         config.put("partitionerType", "default");
         config.put("timePartitionPattern", "yyyy-MM-dd");
@@ -212,7 +232,7 @@ public class ConnectorConfigTest {
         config.put("secretAccessKey", "aws-s3");
         config.put("bucket", "testbucket");
         config.put("region", "localhost");
-        config.put("endpoint", "us-standard");
+        config.put("endpoint", "https://us-standard");
         config.put("pathPrefix", "pulsar/");
         config.put("formatType", "bytes");
         config.put("partitionerType", "default");


### PR DESCRIPTION
Fixes #14 

### Motivation


This fixes a misleading Java heap space error during runtime because the provider SDK requires the URI scheme

### Modifications

Validates the URI scheme of the endpoint, and also cleans up some code.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added test that expects failure when using a malformed endpoint

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API: (yes / *no*)
  - The schema: (yes / *no* / don't know)
  - The default values of configurations: (yes / *no*)
  - The wire protocol: (yes / *no*)
  - The rest endpoints: (yes / *no*)
  - The admin cli options: (yes / *no*)
  - Anything that affects deployment: (yes / *no* / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (*not applicable* / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
