### PR TITLE
[#154][docs] Add pathPrefix to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The Cloud Storage sink connector supports the following properties.
 | `pendingQueueSize`              | int     | False    | 100          | The number of records buffered in queue. By default, it is `batchSize * 10`. You can set it manually.                                                                                                                   |
 | `useHumanReadableSchemaVersion` | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`            | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
+| `pathPrefix`                    | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
 
 #### Storage Provider: Google Cloud Storage
 
@@ -83,6 +84,7 @@ The Cloud Storage sink connector supports the following properties.
 | `pendingQueueSize`                | int     | False    | 100          | The number of records buffered in queue. By default, it is `batchSize * 10`. You can set it manually.                                                                                                                   |
 | `useHumanReadableSchemaVersion`   | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`              | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
+| `pathPrefix`                      | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
 
 ### Configure Cloud Storage sink connector
 

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -78,6 +78,7 @@ The Cloud Storage sink connector supports the following properties.
 | `pendingQueueSize`              | int     | False    | 100          | The number of records buffered in queue. By default, it is `batchSize * 10`. You can set it manually.                                                                                                                   |
 | `useHumanReadableSchemaVersion` | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`            | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
+| `pathPrefix`                    | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
 
 ### Storage Provider: Google Cloud Storage
 
@@ -102,6 +103,7 @@ The Cloud Storage sink connector supports the following properties.
 | `pendingQueueSize`                | int     | False    | 100          | The number of records buffered in queue. By default, it is `batchSize * 10`. You can set it manually.                                                                                                                   |
 | `useHumanReadableSchemaVersion`   | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`              | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
+| `pathPrefix`                      | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
 
 ## Configure Cloud Storage sink connector
 


### PR DESCRIPTION
Fixes #154 


### Motivation


Adds pathPrefix description to docs.


This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

**no**

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
