### PR TITLE
Make compression algorithm configurable for parquet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The Cloud Storage sink connector supports the following properties.
 | `useHumanReadableSchemaVersion` | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`            | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
 | `pathPrefix`                    | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
+| `avroCodec`                     | String  | False    | snappy       | Compression codec used when formatType=`avro`. Available compression types are: null (no compression), deflate, bzip2, xz, zstandard, snappy.                                                                           |
+| `parquetCodec`                  | String  | False    | gzip         | Compression codec used when formatType=`parquet`. Available compression types are: null (no compression), snappy, gzip, lzo, brotli, lz4, zstd.                                                                         |
 
 #### Storage Provider: Google Cloud Storage
 
@@ -85,6 +87,8 @@ The Cloud Storage sink connector supports the following properties.
 | `useHumanReadableSchemaVersion`   | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`              | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
 | `pathPrefix`                      | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
+| `avroCodec`                     | String  | False    | snappy       | Compression codec used when formatType=`avro`. Available compression types are: null (no compression), deflate, bzip2, xz, zstandard, snappy.                                                                           |
+| `parquetCodec`                  | String  | False    | gzip         | Compression codec used when formatType=`parquet`. Available compression types are: null (no compression), snappy, gzip, lzo, brotli, lz4, zstd.                                                                         |
 
 ### Configure Cloud Storage sink connector
 

--- a/docs/io-cloud-storage-sink.md
+++ b/docs/io-cloud-storage-sink.md
@@ -79,6 +79,8 @@ The Cloud Storage sink connector supports the following properties.
 | `useHumanReadableSchemaVersion` | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`            | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
 | `pathPrefix`                    | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
+| `avroCodec`                     | String  | False    | snappy       | Compression codec used when formatType=`avro`. Available compression types are: null (no compression), deflate, bzip2, xz, zstandard, snappy.                                                                           |
+| `parquetCodec`                  | String  | False    | gzip         | Compression codec used when formatType=`parquet`. Available compression types are: null (no compression), snappy, gzip, lzo, brotli, lz4, zstd.                                                                         |
 
 ### Storage Provider: Google Cloud Storage
 
@@ -104,6 +106,8 @@ The Cloud Storage sink connector supports the following properties.
 | `useHumanReadableSchemaVersion`   | Boolean | False    | false        | Use a human-readable format string for the schema version in the message metadata. If it is set to `true`, the schema version is in plain string format. Otherwise, the schema version is in hex-encoded string format. |
 | `skipFailedMessages`              | Boolean | False    | false        | Configure whether to skip a message which it fails to be processed. If it is set to `true`, the connector will skip the failed messages by `ack` it. Otherwise, the connector will `fail` the message.                  |
 | `pathPrefix`                      | String  | False    | false        | If it is set, the output files are stored in a folder under the given bucket path. The `pathPrefix` must be in the format of `xx/xxx/`.                                                                                 |
+| `avroCodec`                       | String  | False    | snappy       | Compression codec used when formatType=`avro`. Available compression types are: null (no compression), deflate, bzip2, xz, zstandard, snappy.                                                                           |
+| `parquetCodec`                    | String  | False    | gzip         | Compression codec used when formatType=`parquet`. Available compression types are: null (no compression), snappy, gzip, lzo, brotli, lz4, zstd.                                                                         |
 
 ## Configure Cloud Storage sink connector
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -34,7 +34,6 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.parquet.format.CompressionCodec;
 import org.apache.pulsar.io.jcloud.format.AvroFormat;
 import org.apache.pulsar.io.jcloud.format.BytesFormat;
 import org.apache.pulsar.io.jcloud.format.Format;

--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -34,6 +34,7 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.parquet.format.CompressionCodec;
 import org.apache.pulsar.io.jcloud.format.AvroFormat;
 import org.apache.pulsar.io.jcloud.format.BytesFormat;
 import org.apache.pulsar.io.jcloud.format.Format;
@@ -83,6 +84,10 @@ public class BlobStoreAbstractConfig implements Serializable {
     // The AVRO codec.
     // Options: null, deflate, bzip2, xz, zstandard, snappy
     private String avroCodec = "snappy";
+
+    // The Parquet codec.
+    // Options: null, snappy, gzip, lzo, brotli, lz4, zstd
+    private String parquetCodec = "gzip";
 
     private String timePartitionPattern;
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -64,6 +64,8 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     private boolean useHumanReadableMessageId;
     private boolean useHumanReadableSchemaVersion;
 
+    private CompressionCodecName compressionCodecName = CompressionCodecName.GZIP;
+
     @Override
     public String getExtension() {
         return ".parquet";
@@ -74,6 +76,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
         this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
+        this.compressionCodecName = CompressionCodecName.fromConf(configuration.getParquetCodec());
     }
 
     @Override
@@ -217,7 +220,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                 parquetWriter = ProtobufParquetWriter.builder(file)
                         .withPageSize(pageSize)
                         .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
-                        .withCompressionCodec(CompressionCodecName.GZIP)
+                        .withCompressionCodec(compressionCodecName)
                         .withDescriptor(descriptor)
                         .build();
             } else if (rootAvroSchema != null) {
@@ -225,7 +228,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                         .builder(file)
                         .withPageSize(pageSize)
                         .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
-                        .withCompressionCodec(CompressionCodecName.GZIP)
+                        .withCompressionCodec(compressionCodecName)
                         .withSchema(rootAvroSchema).build();
             } else {
                 throw new UnsupportedOperationException("Cannot init parquet writer");


### PR DESCRIPTION
### Motivation
In the parquet format the compression is always `gzip`. The compressor mechanism passes through the hadoop library that has a memory leak for the gzip codec, see https://issues.apache.org/jira/browse/HADOOP-12007
There's no fix available yet. The only way to avoid the leak it would be to use another algorithm. 

### Modifications

* Added new config option `parquetCodec` (similar to ´AvroCodec´) that accepts a String. The string must be a available compression algorithm. The default value is still `gzip` for compatibiliy.
* Added docs

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
