### PR TITLE
Move log 'Skip flushing because the pending flush is empty' to debug level

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -83,7 +83,6 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
     private final AtomicLong currentBatchSize = new AtomicLong(0L);
     private final AtomicLong currentBatchBytes = new AtomicLong(0L);
     private ArrayBlockingQueue<Record<GenericRecord>> pendingFlushQueue;
-    private ArrayBlockingQueue<Record<GenericRecord>> pendingFlushQueue;
     private final AtomicBoolean isFlushRunning = new AtomicBoolean(false);
     private SinkContext sinkContext;
     private volatile boolean isRunning = false;

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -83,6 +83,7 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
     private final AtomicLong currentBatchSize = new AtomicLong(0L);
     private final AtomicLong currentBatchBytes = new AtomicLong(0L);
     private ArrayBlockingQueue<Record<GenericRecord>> pendingFlushQueue;
+    private ArrayBlockingQueue<Record<GenericRecord>> pendingFlushQueue;
     private final AtomicBoolean isFlushRunning = new AtomicBoolean(false);
     private SinkContext sinkContext;
     private volatile boolean isRunning = false;
@@ -203,12 +204,12 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
         }
 
         if (pendingFlushQueue.isEmpty()) {
-            log.info("Skip flushing, because the pending flush queue is empty ...");
+            log.debug("Skip flushing because the pending flush queue is empty...");
             return;
         }
 
         if (!isFlushRunning.compareAndSet(false, true)) {
-            log.info("Skip flushing, because there is an outstanding flush ...");
+            log.info("Skip flushing because there is an outstanding flush...");
             return;
         }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
Every time a new flush is scheduled (`batchTimeMs` 1sec by default) there's a log line that says the queue is empty.

### Modifications

* Moved that log line to debug level 
