### PR TITLE
[#472][misc] Update PULL_REQUEST_TEMPLATE.md for auto-labeling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
+
 <!--
 ### Contribution Checklist
-  
-  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
-    Skip *Issue XYZ* if there is no associated github issue for this pull request.
-    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.
 
   - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
   
@@ -25,7 +22,6 @@ Fixes #<xyz>
 Master Issue: #<xyz>
 
 ### Motivation
-
 
 *Explain here the context, and why you're making that change. What is the problem you're trying to solve.*
 
@@ -50,25 +46,23 @@ This change is already covered by existing tests, such as *(please describe test
 This change added tests and can be verified as follows:
 
 *(example:)*
-  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
-  - *Extended integration test for recovery after broker failure*
-
-### Does this pull request potentially affect one of the following parts:
-
-*If `yes` was chosen, please highlight the changes*
-
-  - Dependencies (does it add or upgrade a dependency): (yes / no)
-  - The public API: (yes / no)
-  - The schema: (yes / no / don't know)
-  - The default values of configurations: (yes / no)
-  - The wire protocol: (yes / no)
-  - The rest endpoints: (yes / no)
-  - The admin cli options: (yes / no)
-  - Anything that affects deployment: (yes / no / don't know)
+- *Added integration tests for end-to-end deployment with large payloads (10MB)*
+- *Extended integration test for recovery after broker failure*
 
 ### Documentation
 
-  - Does this pull request introduce a new feature? (yes / no)
-  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
-  - If a feature is not applicable for documentation, explain why?
-  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
+Check the box below.
+
+Need to update docs?
+
+- [ ] `doc-required`
+
+  (If you need help on updating docs, create a doc issue)
+
+- [ ] `no-need-doc`
+
+  (Please explain why)
+
+- [ ] `doc`
+
+  (If this PR contains doc changes)


### PR DESCRIPTION
Fixes #472 

### Motivation

The current PR template is not compatible with the auto-labeling for the docs. It also contains a copy-pasted section that is only relevant to apache/pulsar and not this connector in particular.

### Modifications

Added the docs section for auto labeling
Removed the misleading section about components

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.


