### PR TITLE
Bump checkstyle to 8.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,11 @@
 
     <!-- build plugin dependencies -->
     <license.plugin.version>3.0</license.plugin.version>
-    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     <nifi.nar.plugin.version>1.2.0</nifi.nar.plugin.version>
-    <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
+    <puppycrawl.checkstyle.version>8.29</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -33,6 +33,21 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <!-- Checks that there are no tab characters in the file. -->
     </module>
 
+    <module name="LineLength">
+        <!-- Checks if a line is too long. -->
+        <property name="max" value="120"/>
+        <property name="severity" value="error"/>
+
+        <!--
+          The default ignore pattern exempts the following elements:
+            - import statements
+            - long URLs inside comments
+        -->
+
+        <property name="ignorePattern"
+                  value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
+    </module>
+
     <module name="RegexpSingleline">
         <!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
         <property name="format" value="((//.*)|(\*.*))TODO\("/>
@@ -57,12 +72,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <property name="fileNamePattern" value=".*Tests\.java$"/>
     </module>
 
-    <!-- Allow use of comment to suppress javadocstyle -->
-    <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
-        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
-        <property name="checkFormat" value="$1"/>
-    </module>
     <module name="SuppressionFilter">
         <property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml"/>
     </module>
@@ -148,21 +157,21 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         -->
 
+        <!-- Allow use of comment to suppress javadocstyle -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
+
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected"/>
             <property name="severity" value="error"/>
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
         </module>
-
-        <!-- Check that paragraph tags are used correctly in Javadoc. -->
-        <module name="JavadocParagraph"/>
 
         <module name="JavadocType">
             <property name="scope" value="protected"/>
@@ -282,24 +291,9 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         <!--
 
-        LENGTH and CODING CHECKS
+        CODING CHECKS
 
         -->
-
-        <module name="LineLength">
-            <!-- Checks if a line is too long. -->
-            <property name="max" value="120"/>
-            <property name="severity" value="error"/>
-
-            <!--
-              The default ignore pattern exempts the following elements:
-                - import statements
-                - long URLs inside comments
-            -->
-
-            <property name="ignorePattern"
-                      value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
-        </module>
 
         <module name="LeftCurly">
             <!-- Checks for placement of the left curly brace ('{'). -->
@@ -440,9 +434,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
             -->
             <property name="severity" value="error"/>
         </module>
-
-        <!-- Required to support SuppressWarningsComment -->
-        <module name="FileContentsHolder"/>
 
     </module>
 </module>

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -119,8 +119,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             switch (record.getSchemaType()) {
                 case AVRO:
                 case JSON:
-                case PROTOBUF:
-                {
+                case PROTOBUF: {
                     List<Field> fields = record.getFields();
                     Map<String, Object> result = new LinkedHashMap<>(fields.size());
                     for (Field field : fields) {

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSink.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.io.jcloud.sink;
 
 import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_AWSS3V2;
-
 import java.io.IOException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/apache/pulsar/io/jcloud/writer/JCloudsBlobWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/writer/JCloudsBlobWriter.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_AWSS3
 import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_GCS;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/apache/pulsar/io/jcloud/writer/S3BlobWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/writer/S3BlobWriter.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.io.jcloud.writer;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.jcloud.sink.CloudStorageSinkConfig;

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -136,8 +136,7 @@ public class JsonFormatTest extends FormatTestBase {
             case PROTOBUF_NATIVE:
                 assertEquals((DynamicMessage) msgValue.getNativeObject(), record);
                 break;
-            default:
-            {
+            default: {
                 for (String fieldName : record.keySet()) {
                     Field genericField = fields.stream().filter(field ->
                             field.getName().equals(fieldName)).findFirst().orElse(null);

--- a/src/test/java/org/apache/pulsar/io/jcloud/writer/S3BlobWriterTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/writer/S3BlobWriterTest.java
@@ -19,11 +19,9 @@
 package org.apache.pulsar.io.jcloud.writer;
 
 import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_AWSS3V2;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.pulsar.io.jcloud.sink.CloudStorageSinkConfig;
 import org.junit.Test;
 


### PR DESCRIPTION
### Motivation

closes #11 
This PR bumps checkstyle to 8.29

### Modifications

upgrading checkstyle version to 8.29
upgrading maven-checkstyle-plugin version to 3.1.1
fix violations due to checkstyle breaking changes

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.
