### PR TITLE
Fix Bytes schema is conversed to AutoConsume schema

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
@@ -75,7 +75,7 @@ public class AvroRecordUtil {
             Record<GenericRecord> record) {
 
         org.apache.pulsar.client.api.Schema<GenericRecord> schema = record.getSchema();
-        if (record.getValue().getSchemaVersion() == null) {
+        if (record.getValue().getSchemaVersion() == null && record.getValue().getSchemaType() != SchemaType.BYTES) {
             org.apache.pulsar.client.api.Schema<GenericRecord> internalSchema =
                     getPulsarInternalSchema(record.getMessage().orElse(null));
             if (internalSchema != null) {


### PR DESCRIPTION
### Motivation
Fix an NPE caused by [PR315](https://github.com/streamnative/pulsar-io-cloud-storage/pull/315).
The PR315 adds the below code block. If there is a Bytes schema in the record, the `record.getValue().getSchemaVersion() ` will be null, and `getPulsarInternalSchema(record.getMessage().orElse(null))` will return the consumer schema which may be an AutoSchema.
```java
 if (record.getValue().getSchemaVersion() == null) {
            org.apache.pulsar.client.api.Schema<GenericRecord> internalSchema =
                    getPulsarInternalSchema(record.getMessage().orElse(null));
            if (internalSchema != null) {
                schema = recoverGenericProtobufNativeSchemaFromInternalSchema(internalSchema);
            }
        }
```

If the `internalSchema` is an AutoConusme Schema, `schema.getSchemaInfo()` will be null. And the `schema.getSchemaInfo().getType() `will report an NPE.
https://github.com/streamnative/pulsar-io-cloud-storage/blob/eed5d1765f3ef108550d307618e49fd55b225851/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java#L96-L99
### Modifications
Skip this check for Bytes schema.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (10MB)*
- *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
