### PR TITLE
[fix][sink] Fix sink failing upon schema retrieval exceptions

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -248,7 +248,15 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
         for (List<Record<GenericRecord>> singleTopicRecordsToInsert : recordsToInsertByTopic.values()) {
             Record<GenericRecord> firstRecord = singleTopicRecordsToInsert.get(0);
-            Schema<GenericRecord> schema = getPulsarSchema(firstRecord);
+            Schema<GenericRecord> schema;
+            try {
+                schema = getPulsarSchema(firstRecord);
+            } catch (Exception e) {
+                log.error("Failed to retrieve message schema", e);
+                bulkHandleFailedRecords(singleTopicRecordsToInsert);
+                return;
+            }
+
             if (!format.doSupportPulsarSchemaType(schema.getSchemaInfo().getType())) {
                 log.warn("sink does not support schema type {}", schema.getSchemaInfo().getType());
                 bulkHandleFailedRecords(singleTopicRecordsToInsert);


### PR DESCRIPTION
### Motivation

In case there is an Exception happening during the retrieval of the schema, the sink fails.

### Modifications

Exceptions happening during schema retrieval are caught, logged and records are failed/nacked.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (10MB)*
- *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
