### PR TITLE
Fix JsonFormat convert failed when use array jsonBytes or jsonString.

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -63,7 +63,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
     private static final TypeReference<Map<String, Object>> TYPEREF = new TypeReference<>() {};
     private static final TypeReference<List<Map<String, Object>>> ARRAY_TYPEREF = new TypeReference<>() {};
-    private static TypeReference PRIORITY_TRY_TYPEREF = TYPEREF;
+    private static TypeReference priorityTryTyperef = TYPEREF;
 
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
@@ -188,12 +188,12 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
      * @throws IOException
      */
     private static Map<String, Object> dynamicReadValue(JsonParser jsonParser) throws IOException {
-        if (PRIORITY_TRY_TYPEREF == TYPEREF) {
+        if (priorityTryTyperef == TYPEREF) {
             try {
                 return JSON_MAPPER.get().readValue(jsonParser, TYPEREF);
             } catch (MismatchedInputException e) {
                 log.info("Use Map<String, Object> read json failed, try to use List<Map<String, Object>>");
-                PRIORITY_TRY_TYPEREF = ARRAY_TYPEREF;
+                priorityTryTyperef = ARRAY_TYPEREF;
                 return readValueForArrayType(jsonParser);
             }
         } else {
@@ -201,7 +201,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
                 return readValueForArrayType(jsonParser);
             } catch (MismatchedInputException e) {
                 log.info("Use List<Map<String, Object>> read json failed, try to use Map<String, Object>");
-                PRIORITY_TRY_TYPEREF = TYPEREF;
+                priorityTryTyperef = TYPEREF;
                 return JSON_MAPPER.get().readValue(jsonParser, TYPEREF);
             }
         }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -67,9 +67,9 @@ public abstract class FormatTestBase extends PulsarTestBase {
             TopicName.get("test-parquet-kv" + RandomStringUtils.randomAlphabetic(5));
     private static final TopicName protobufNativeTopicName =
             TopicName.get("test-parquet-protobuf-native" + RandomStringUtils.randomAlphabetic(5));
-    protected static final TopicName jsonBytesTopicName =
+    protected static TopicName jsonBytesTopicName =
             TopicName.get("test-json-bytes-parquet-json" + RandomStringUtils.randomAlphabetic(5));
-    protected static final TopicName jsonStringTopicName =
+    protected static TopicName jsonStringTopicName =
             TopicName.get("test-json-string-parquet-json" + RandomStringUtils.randomAlphabetic(5));
 
     @BeforeClass

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -67,6 +67,10 @@ public abstract class FormatTestBase extends PulsarTestBase {
             TopicName.get("test-parquet-kv" + RandomStringUtils.randomAlphabetic(5));
     private static final TopicName protobufNativeTopicName =
             TopicName.get("test-parquet-protobuf-native" + RandomStringUtils.randomAlphabetic(5));
+    protected static final TopicName jsonBytesTopicName =
+            TopicName.get("test-json-bytes-parquet-json" + RandomStringUtils.randomAlphabetic(5));
+    protected static final TopicName jsonStringTopicName =
+            TopicName.get("test-json-string-parquet-json" + RandomStringUtils.randomAlphabetic(5));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -81,6 +85,10 @@ public abstract class FormatTestBase extends PulsarTestBase {
         pulsarAdmin.topics().createSubscription(avroTopicName.toString(), "test", MessageId.earliest);
         pulsarAdmin.topics().createPartitionedTopic(protobufNativeTopicName.toString(), 1);
         pulsarAdmin.topics().createSubscription(protobufNativeTopicName.toString(), "test", MessageId.earliest);
+        pulsarAdmin.topics().createPartitionedTopic(jsonBytesTopicName.toString(), 1);
+        pulsarAdmin.topics().createSubscription(jsonBytesTopicName.toString(), "test", MessageId.earliest);
+        pulsarAdmin.topics().createPartitionedTopic(jsonStringTopicName.toString(), 1);
+        pulsarAdmin.topics().createSubscription(jsonStringTopicName.toString(), "test", MessageId.earliest);
     }
 
     public abstract Format<GenericRecord> getFormat();

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -68,7 +68,8 @@ public class JsonFormatTest extends FormatTestBase {
         );
 
         String json = JSON_MAPPER.get().writeValueAsString(testRecords);
-        sendTypedMessages(jsonBytesTopicName.toString(), SchemaType.BYTES, Arrays.asList(json.getBytes(), json.getBytes()), Optional.empty(), byte[].class);
+        sendTypedMessages(jsonBytesTopicName.toString(), SchemaType.BYTES,
+                Arrays.asList(json.getBytes(), json.getBytes()), Optional.empty(), byte[].class);
 
         Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonBytesTopicName);
         consumerMessages(jsonBytesTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);
@@ -83,7 +84,8 @@ public class JsonFormatTest extends FormatTestBase {
         );
 
         String json = JSON_MAPPER.get().writeValueAsString(testRecords);
-        sendTypedMessages(jsonStringTopicName.toString(), SchemaType.STRING, Arrays.asList(json, json), Optional.empty(), String.class);
+        sendTypedMessages(jsonStringTopicName.toString(), SchemaType.STRING,
+                Arrays.asList(json, json), Optional.empty(), String.class);
 
         Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonStringTopicName);
         consumerMessages(jsonStringTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);


### PR DESCRIPTION
### Motivation

#623 

### Modifications

- When using `Map<String,Object>` convert failed, try to use `List<Map<String, Object>>` the second convert.
- Which way `Map<String, Object>` and `List<Map<String, Object>>` can be converted successfully, the next convert will try to use it first.


### Verifying this change

- Add `testJsonBytesRecordWriter` and `testJsonStringRecordWriter` to cover it.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
