### PR TITLE
Fix JsonFormat convert failed when use array jsonBytes or jsonString.

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -63,7 +63,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
     private static final TypeReference<Map<String, Object>> TYPEREF = new TypeReference<>() {};
     private static final TypeReference<List<Map<String, Object>>> ARRAY_TYPEREF = new TypeReference<>() {};
-    private static TypeReference priorityTryTyperef = TYPEREF;
+    private TypeReference priorityTryTyperef = TYPEREF;
 
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
@@ -187,7 +187,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
      * @return
      * @throws IOException
      */
-    private static Map<String, Object> dynamicReadValue(JsonParser jsonParser) throws IOException {
+    private Map<String, Object> dynamicReadValue(JsonParser jsonParser) throws IOException {
         if (priorityTryTyperef == TYPEREF) {
             try {
                 return JSON_MAPPER.get().readValue(jsonParser, TYPEREF);
@@ -207,7 +207,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         }
     }
 
-    private static Map<String, Object> readValueForArrayType(JsonParser jsonParser) throws IOException {
+    private Map<String, Object> readValueForArrayType(JsonParser jsonParser) throws IOException {
         Map<String, Object> result = new LinkedHashMap<>();
         List<Map<String, Object>> valueList =
                 JSON_MAPPER.get().readValue(jsonParser, ARRAY_TYPEREF);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -20,9 +20,12 @@ package org.apache.pulsar.io.jcloud.format;
 
 import static com.fasterxml.jackson.core.json.JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat.Printer;
 import java.io.IOException;
@@ -57,7 +60,10 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         return mapper;
     });
 
-    public static final TypeReference<Map<String, Object>> TYPEREF = new TypeReference<Map<String, Object>>() {};
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final TypeReference<Map<String, Object>> TYPEREF = new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, Object>>> ARRAY_TYPEREF = new TypeReference<>() {};
+    private static TypeReference priorityTryTyperef = TYPEREF;
 
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
@@ -141,16 +147,16 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
                     if (record.getNativeObject() instanceof DynamicMessage) {
                         Printer printer = com.google.protobuf.util.JsonFormat.printer();
                         String json = printer.print((DynamicMessage) record.getNativeObject());
-                        return JSON_MAPPER.get().readValue(json, TYPEREF);
+                        return dynamicReadValue(JSON_FACTORY.createParser(json));
                     }
                     break;
                 default:
                     throw new UnsupportedOperationException("Unsupported value schemaType=" + record.getSchemaType());
             }
         } else if (record.getSchemaType() == SchemaType.STRING) {
-            return JSON_MAPPER.get().readValue((String) record.getNativeObject(), TYPEREF);
+            return dynamicReadValue(JSON_FACTORY.createParser((String) record.getNativeObject()));
         } else if (record.getSchemaType() == SchemaType.BYTES) {
-            return JSON_MAPPER.get().readValue((byte[]) record.getNativeObject(), TYPEREF);
+            return dynamicReadValue(JSON_FACTORY.createParser((byte[]) record.getNativeObject()));
         } else if (record.getSchemaType() == SchemaType.KEY_VALUE) {
             Map<String, Object> jsonKeyValue = new LinkedHashMap<>();
             KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) schema;
@@ -170,5 +176,43 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         if (record != null) {
             jsonKeyValue.put(key, convertRecordToObject((GenericRecord) record, schema));
         }
+    }
+
+    /**
+     * This method will try use TYPEREF and ARRAY_TYPEREF to read json value.
+     *
+     * Once the read is successful, the same type is used for the next read.
+     *
+     * @param jsonParser
+     * @return
+     * @throws IOException
+     */
+    private static Map<String, Object> dynamicReadValue(JsonParser jsonParser) throws IOException {
+        if (priorityTryTyperef == TYPEREF) {
+            try {
+                return JSON_MAPPER.get().readValue(jsonParser, TYPEREF);
+            } catch (MismatchedInputException e) {
+                log.info("Use Map<String, Object> read json failed, try to use List<Map<String, Object>>");
+                priorityTryTyperef = ARRAY_TYPEREF;
+                return readValueForArrayType(jsonParser);
+            }
+        } else {
+            try {
+                return readValueForArrayType(jsonParser);
+            } catch (MismatchedInputException e) {
+                log.info("Use List<Map<String, Object>> read json failed, try to use Map<String, Object>");
+                priorityTryTyperef = TYPEREF;
+                return JSON_MAPPER.get().readValue(jsonParser, TYPEREF);
+            }
+        }
+    }
+
+    private static Map<String, Object> readValueForArrayType(JsonParser jsonParser) throws IOException {
+        Map<String, Object> result = new LinkedHashMap<>();
+        List<Map<String, Object>> valueList =
+                JSON_MAPPER.get().readValue(jsonParser, ARRAY_TYPEREF);
+        // To maintain compatibility, put the valueList in the map.
+        result.put("value", valueList);
+        return result;
     }
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -67,6 +67,10 @@ public abstract class FormatTestBase extends PulsarTestBase {
             TopicName.get("test-parquet-kv" + RandomStringUtils.randomAlphabetic(5));
     private static final TopicName protobufNativeTopicName =
             TopicName.get("test-parquet-protobuf-native" + RandomStringUtils.randomAlphabetic(5));
+    protected static TopicName jsonBytesTopicName =
+            TopicName.get("test-json-bytes-parquet-json" + RandomStringUtils.randomAlphabetic(5));
+    protected static TopicName jsonStringTopicName =
+            TopicName.get("test-json-string-parquet-json" + RandomStringUtils.randomAlphabetic(5));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -81,6 +85,10 @@ public abstract class FormatTestBase extends PulsarTestBase {
         pulsarAdmin.topics().createSubscription(avroTopicName.toString(), "test", MessageId.earliest);
         pulsarAdmin.topics().createPartitionedTopic(protobufNativeTopicName.toString(), 1);
         pulsarAdmin.topics().createSubscription(protobufNativeTopicName.toString(), "test", MessageId.earliest);
+        pulsarAdmin.topics().createPartitionedTopic(jsonBytesTopicName.toString(), 1);
+        pulsarAdmin.topics().createSubscription(jsonBytesTopicName.toString(), "test", MessageId.earliest);
+        pulsarAdmin.topics().createPartitionedTopic(jsonStringTopicName.toString(), 1);
+        pulsarAdmin.topics().createSubscription(jsonStringTopicName.toString(), "test", MessageId.earliest);
     }
 
     public abstract Format<GenericRecord> getFormat();

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -72,7 +72,7 @@ public class JsonFormatTest extends FormatTestBase {
             sendTypedMessages(jsonBytesTopicName.toString(), SchemaType.BYTES,
                     Arrays.asList(json.getBytes(), json.getBytes()), Optional.empty(), byte[].class);
 
-            Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonBytesTopicName);
+            Consumer<Message<GenericRecord>> handle = getJsonByteAndStringHandler(jsonBytesTopicName);
             consumerMessages(jsonBytesTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);
         } catch (Exception e) {
             fail(e.getMessage());
@@ -92,11 +92,27 @@ public class JsonFormatTest extends FormatTestBase {
             sendTypedMessages(jsonStringTopicName.toString(), SchemaType.STRING,
                     Arrays.asList(json, json), Optional.empty(), String.class);
 
-            Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonStringTopicName);
+            Consumer<Message<GenericRecord>> handle = getJsonByteAndStringHandler(jsonStringTopicName);
             consumerMessages(jsonStringTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);
         } catch (Exception e) {
             fail(e.getMessage());
         }
+    }
+
+    private Consumer<Message<GenericRecord>> getJsonByteAndStringHandler(TopicName topic) {
+        return msg -> {
+            try {
+                Schema<GenericRecord> schema = (Schema<GenericRecord>) msg.getReaderSchema().get();
+                initSchema(schema);
+                Map<String, Object> message = getJSONMessage(topic, msg);
+                Assert.assertEquals(message.size(), 2);
+                List<Map<String, Object>> value = (List<Map<String, Object>>) message.get("value");
+                Assert.assertEquals(value.size(), 3);
+            } catch (Exception e) {
+                log.error("formatter handle message is fail", e);
+                fail();
+            }
+        };
     }
 
     @Override

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/JsonFormatTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.DynamicMessage;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,9 +36,12 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.bo.TestRecord;
 import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteSource;
 import org.junit.Assert;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +58,46 @@ public class JsonFormatTest extends FormatTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(JsonFormatTest.class);
     private JsonFormat format = new JsonFormat();
+
+    @Test
+    public void testJsonBytesRecordWriter() {
+        List<TestRecord> testRecords = Arrays.asList(
+                new TestRecord("key1", 1, null),
+                new TestRecord("key1", 1, new TestRecord.TestSubRecord("aaa")),
+                new TestRecord("key2", 2, new TestRecord.TestSubRecord("aaa"))
+        );
+
+        try {
+            String json = JSON_MAPPER.get().writeValueAsString(testRecords);
+            sendTypedMessages(jsonBytesTopicName.toString(), SchemaType.BYTES,
+                    Arrays.asList(json.getBytes(), json.getBytes()), Optional.empty(), byte[].class);
+
+            Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonBytesTopicName);
+            consumerMessages(jsonBytesTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testJsonStringRecordWriter() {
+        List<TestRecord> testRecords = Arrays.asList(
+                new TestRecord("key1", 1, null),
+                new TestRecord("key1", 1, new TestRecord.TestSubRecord("aaa")),
+                new TestRecord("key2", 2, new TestRecord.TestSubRecord("aaa"))
+        );
+
+        try {
+            String json = JSON_MAPPER.get().writeValueAsString(testRecords);
+            sendTypedMessages(jsonStringTopicName.toString(), SchemaType.STRING,
+                    Arrays.asList(json, json), Optional.empty(), String.class);
+
+            Consumer<Message<GenericRecord>> handle = getJSONMessageConsumer(jsonStringTopicName);
+            consumerMessages(jsonStringTopicName.toString(), Schema.AUTO_CONSUME(), handle, 2, 2000);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
 
     @Override
     public Format<GenericRecord> getFormat() {


### PR DESCRIPTION
### Motivation

#623 

### Modifications

- When using `Map<String,Object>` convert failed, try to use `List<Map<String, Object>>` the second convert.
- Which way `Map<String, Object>` and `List<Map<String, Object>>` can be converted successfully, the next convert will try to use it first.


### Verifying this change

- Add `testJsonBytesRecordWriter` and `testJsonStringRecordWriter` to cover it.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
