### PR TITLE
Upgrade depends pulsar version to 2.11.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
-    <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
+    <pulsar.version>2.11.0.4</pulsar.version>
     <parquet.version>1.12.2</parquet.version>
     <awsjavasdk.version>1.12.148</awsjavasdk.version>
     <aws.java.sdk2.version>2.16.1</aws.java.sdk2.version>

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -308,14 +308,15 @@ public abstract class FormatTestBase extends PulsarTestBase {
     }
 
     protected void initSchema(Schema<GenericRecord> schema) {
+        Schema<GenericRecord> convertSchema = schema;
         if (schema instanceof AutoConsumeSchema) {
             AutoConsumeSchema autoConsumeSchema = (AutoConsumeSchema) schema;
-            schema = (Schema<GenericRecord>) autoConsumeSchema.atSchemaVersion(null);
+            convertSchema = (Schema<GenericRecord>) autoConsumeSchema.atSchemaVersion(null);
         }
         final BlobStoreAbstractConfig config = getBlobStoreAbstractConfig();
         ((InitConfiguration<BlobStoreAbstractConfig>) getFormat()).configure(config);
-        Assert.assertTrue(getFormat().doSupportPulsarSchemaType(schema.getSchemaInfo().getType()));
-        getFormat().initSchema(schema);
+        Assert.assertTrue(getFormat().doSupportPulsarSchemaType(convertSchema.getSchemaInfo().getType()));
+        getFormat().initSchema(convertSchema);
     }
 
     protected void validMetadata(org.apache.avro.generic.GenericRecord record, Message<GenericRecord> message) {

--- a/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/format/FormatTestBase.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.KeyValue;
@@ -307,6 +308,10 @@ public abstract class FormatTestBase extends PulsarTestBase {
     }
 
     protected void initSchema(Schema<GenericRecord> schema) {
+        if (schema instanceof AutoConsumeSchema) {
+            AutoConsumeSchema autoConsumeSchema = (AutoConsumeSchema) schema;
+            schema = (Schema<GenericRecord>) autoConsumeSchema.atSchemaVersion(null);
+        }
         final BlobStoreAbstractConfig config = getBlobStoreAbstractConfig();
         ((InitConfiguration<BlobStoreAbstractConfig>) getFormat()).configure(config);
         Assert.assertTrue(getFormat().doSupportPulsarSchemaType(schema.getSchemaInfo().getType()));


### PR DESCRIPTION
### Motivation

Upgrade depends sn-pulsar version to 2.11.0.4 on the master branch to ensure the unit test use the latest pulsar version.

### Modifications

- Change the sn-pulsar version to 2.11.0.4
- Since https://github.com/apache/pulsar/pull/15622 change `Message#getReaderSchema()`  behavior, So, we need add judge on unit test.

### Verifying this change



### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
