### PR TITLE
Optimize Azure blob storage connector config validation logic

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -123,10 +123,6 @@ public class BlobStoreAbstractConfig implements Serializable {
             checkArgument(isNotBlank(region) || isNotBlank(endpoint),
                     "Either the aws-end-point or aws-region must be set.");
         }
-        if (provider.equalsIgnoreCase(PROVIDER_AZURE)) {
-            checkArgument(isNotBlank(endpoint),
-                    "endpoint property must be set.");
-        }
         if (isNotBlank(endpoint)) {
             checkArgument(hasURIScheme(endpoint), "endpoint property needs to specify URI scheme.");
         }

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkConfig.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pulsar.io.jcloud.sink;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
@@ -142,6 +145,10 @@ public class CloudStorageSinkConfig extends BlobStoreAbstractConfig {
         if (!useDefaultCredentials && getProvider().equalsIgnoreCase(PROVIDER_AWSS3)) {
             checkNotNull(accessKeyId, "accessKeyId property not set.");
             checkNotNull(secretAccessKey, "secretAccessKey property not set.");
+        }
+        if (getProvider().equalsIgnoreCase(PROVIDER_AZURE) && isEmpty(azureStorageAccountConnectionString)) {
+            checkArgument(isNotBlank(getEndpoint()),
+                    "endpoint property must be set.");
         }
     }
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.io.jcloud.writer;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
@@ -36,21 +35,22 @@ import org.apache.pulsar.io.jcloud.sink.CloudStorageSinkConfig;
 @Slf4j
 public class AzureBlobWriter implements BlobWriter {
 
-    private final BlobContainerClient containerClient;
+    public final BlobContainerClient containerClient;
 
     public AzureBlobWriter(CloudStorageSinkConfig sinkConfig) {
         BlobContainerClientBuilder containerClientBuilder = new BlobContainerClientBuilder();
-        containerClientBuilder.endpoint(sinkConfig.getEndpoint());
         containerClientBuilder.containerName(sinkConfig.getBucket());
 
-        if (isNotEmpty(sinkConfig.getAzureStorageAccountSASToken())) {
+        if (isNotEmpty(sinkConfig.getAzureStorageAccountConnectionString())) {
+            containerClientBuilder.connectionString(sinkConfig.getAzureStorageAccountConnectionString());
+        } else if (isNotEmpty(sinkConfig.getAzureStorageAccountSASToken())) {
+            containerClientBuilder.endpoint(sinkConfig.getEndpoint());
             containerClientBuilder.sasToken(sinkConfig.getAzureStorageAccountSASToken());
-        } else if (!isEmptyAccountNameAccountKey(sinkConfig)) {
+        } else if (isNotEmpty(sinkConfig.getAzureStorageAccountName())
+                              && isNotEmpty(sinkConfig.getAzureStorageAccountKey())) {
+            containerClientBuilder.endpoint(sinkConfig.getEndpoint());
             containerClientBuilder.credential(new StorageSharedKeyCredential(sinkConfig.getAzureStorageAccountName(),
                     sinkConfig.getAzureStorageAccountKey()));
-        } else if (isNotEmpty(sinkConfig.getAzureStorageAccountConnectionString())) {
-            containerClientBuilder.credential(StorageSharedKeyCredential.fromConnectionString(
-                    sinkConfig.getAzureStorageAccountConnectionString()));
         } else {
             throw new IllegalArgumentException("Either azureStorageAccountSASToken or "
                     + "azureStorageAccountName and azureStorageAccountKey or "
@@ -66,13 +66,7 @@ public class AzureBlobWriter implements BlobWriter {
         blobClient.upload(BinaryData.fromBytes(payload.array()));
     }
 
-    private static boolean isEmptyAccountNameAccountKey(CloudStorageSinkConfig sinkConfig) {
-        return (isEmpty(sinkConfig.getAzureStorageAccountName()) || isEmpty(sinkConfig.getAzureStorageAccountKey()));
-    }
-
-
     @Override
     public void close() throws IOException {
-
     }
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
@@ -35,7 +35,7 @@ import org.apache.pulsar.io.jcloud.sink.CloudStorageSinkConfig;
 @Slf4j
 public class AzureBlobWriter implements BlobWriter {
 
-    public final BlobContainerClient containerClient;
+    private final BlobContainerClient containerClient;
 
     public AzureBlobWriter(CloudStorageSinkConfig sinkConfig) {
         BlobContainerClientBuilder containerClientBuilder = new BlobContainerClientBuilder();

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.jcloud;
 
 import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_AWSS3;
+import static org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig.PROVIDER_AZURE;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -292,6 +293,39 @@ public class ConnectorConfigTest {
             config.put("partitionerType", value);
             cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
             cloudStorageSinkConfig.validate();
+        }
+    }
+
+    @Test
+    public void testAllowEndpointEmptyWithAzure() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", PROVIDER_AZURE);
+        config.put("azureStorageAccountConnectionString", "test-connection-string");
+        config.put("bucket", "test-container-name");
+        config.put("formatType", "bytes");
+        config.put("partitionerType", "PARTITION");
+        CloudStorageSinkConfig cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
+        try {
+            cloudStorageSinkConfig.validate();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNotAllowEndpointEmptyWithAzure() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", PROVIDER_AZURE);
+        config.put("azureStorageAccountSASToken", "test-account-sas-token");
+        config.put("bucket", "test-container-name");
+        config.put("formatType", "bytes");
+        config.put("partitionerType", "PARTITION");
+        CloudStorageSinkConfig cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
+        try {
+            cloudStorageSinkConfig.validate();
+            Assert.fail("Should be validate failed.");
+        } catch (Exception e) {
+            Assert.assertEquals("endpoint property must be set.", e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Motivation

For Azure blob storage, when users set `azureStorageAccountConnectionString `, `endpoint` is not required.

### Modifications

- Change `endpoint` validation logic, only validate it when `azureStorageAccountConnectionString` is empty.

### Verifying this change
- Add `testAllowEndpointEmptyWithAzure ` and `testNotAllowEndpointEmptyWithAzure ` to cover it.

### Documentation

Check the box below.

Need to update docs?

- [x] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [ ] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
