### PR TITLE
[DONT MERGE] feat(partitoner):  support global time partitioner

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerType.java
@@ -23,5 +23,12 @@ package org.apache.pulsar.io.jcloud.partitioner;
  */
 public enum PartitionerType {
     PARTITION,
-    TIME;
+    TIME,
+    /**
+     * The global time partitioner.
+     * Using this partitioner gathers all messages from subscribed topics into a single file.
+     * The file path follows the format: `{pathPrefix}{timestamp}.{format ext}`.
+     * For instance: global_time/1700646082956.json
+     */
+    GLOBAL_TIME;
 }

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -275,7 +275,8 @@ public class ConnectorConfigTest {
         try {
             cloudStorageSinkConfig.validate();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("partitionerType property not set properly, available options: partition,time",
+            Assert.assertEquals(
+                    "partitionerType property not set properly, available options: partition,time,global_time",
                     e.getMessage());
         }
         config.put("partitionerType", "invalid");
@@ -283,7 +284,8 @@ public class ConnectorConfigTest {
         try {
             cloudStorageSinkConfig.validate();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("partitionerType property not set properly, available options: partition,time",
+            Assert.assertEquals(
+                    "partitionerType property not set properly, available options: partition,time,global_time",
                     e.getMessage());
         }
         config.put("partitionerType", "default");

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTypeTest.java
@@ -30,5 +30,6 @@ public class PartitionerTypeTest {
     public void testValueOf() {
         assertEquals(PartitionerType.PARTITION, EnumUtils.getEnumIgnoreCase(PartitionerType.class, "partition"));
         assertEquals(PartitionerType.TIME, EnumUtils.getEnumIgnoreCase(PartitionerType.class, "time"));
+        assertEquals(PartitionerType.GLOBAL_TIME, EnumUtils.getEnumIgnoreCase(PartitionerType.class, "global_time"));
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

Support global time partitioner. Using this partitioner gathers all messages from subscribed topics into a single file.
The file path follows the format: `{pathPrefix}{timestamp}.{format ext}`. For instance: global_time/1700646082956.json

### Modifications

- support new partitioner type: GLOBAL_TIME


### How to use

- Configure the partitioner type to `GLOBAL_TIME`:
```yaml
configs:
  provider: "aws-s3"
  bucket: "s3-sink-test"
...
  formatType: "json"
  partitionerType: "GLOBAL_TIME"
  pathPrefix: "global_time/"
...
```

- Run the connector. The connector will flush the messages from all subscribed topics into one single file at a time.

<img width="2013" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/dde3c117-241c-477e-ac7f-4db1be2eb1eb">


### Verifying this change



This change is already covered by existing tests.

- For new feature testing, please see `How to use` section
- I have also tested the other partitioner to avoid regression bug(take time partitioner as an example):
<img width="1269" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/167f6522-6df7-411c-9d78-867b55ae9ce7">

#### Test for large files

- Configure the connector as follows:
```yaml
configs:
  provider: "aws-s3"
  bucket: "s3-sink-test"
...
  formatType: "json"
  partitionerType: "GLOBAL_TIME"
  pathPrefix: "sn_test/"
  batchSize: 100000
  batchTimeMs: 100000
  maxBatchBytes: 104857600
...
```

- Run the connector
- Produce many messages. The result is as follow:
<img width="2060" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/b72236ac-ad8c-470d-b3c1-57cfa6f96f71">

- The reason 52MB occurs is that the current batch flushes because it reaches batchTImeMs before reaching maxBatchBytes.

#### Test for multiple topic patterns subscribe

By using the global time partitioner, the connector can gather messages from different topics into one single file when flushing. Here is how to use it:

- Configure the connector as follows:
```yaml
# Use input specs to support multiple pattern
inputSpecs:
  persistent://public/default/test-s3-.*:
    regexPattern: true
  persistent://public/s3/.*:
    regexPattern: true
configs:
  provider: "aws-s3"
  bucket: "s3-sink-test"
...
  formatType: "json"
  partitionerType: "GLOBAL_TIME"
  pathPrefix: "multiple-pattern/"
  batchSize: 10
  batchTimeMs: 100000
  maxBatchBytes: 104857600
...
```

- Produce messages 
```java
        Producer<String> producer1 = client.newProducer(Schema.STRING)
                .topic("persistent://public/default/test-s3-1")
                .create();

        Producer<String> producer2 = client.newProducer(Schema.STRING)
                .topic("persistent://public/s3/test")
                .create();

        for (int i = 0; i < 10; i++) {
            String message1 = "{\"from-topic\": \"public/default/test-s3-1\"}";
            producer1.send(message1);
            String message2 = "{\"from-topic\": \"s3/test\"}";
            producer2.send(message2);
        }
```

- Here is the result
```
{"from-topic":"public/default/test-s3-1","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIQDEAAYADAA","properties":{}}}
{"from-topic":"s3/test","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIADEOcEGAAwAA==","properties":{}}}
{"from-topic":"public/default/test-s3-1","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIQDEAEYADAA","properties":{}}}
{"from-topic":"s3/test","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIADEOgEGAAwAA==","properties":{}}}
{"from-topic":"public/default/test-s3-1","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIQDEAIYADAA","properties":{}}}
{"from-topic":"s3/test","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIADEOkEGAAwAA==","properties":{}}}
{"from-topic":"public/default/test-s3-1","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIQDEAMYADAA","properties":{}}}
{"from-topic":"s3/test","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIADEOoEGAAwAA==","properties":{}}}
{"from-topic":"public/default/test-s3-1","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIQDEAQYADAA","properties":{}}}
{"from-topic":"s3/test","__message_metadata__":{"schemaVersion":"AAAAAAAAAAA=","messageId":"CIADEOsEGAAwAA==","properties":{}}}

```

#### Test for multiple pods with multiple patterns

In this case, we could start multiple pods that both subscribe to multi-pattern topics. Each pods will use their own buffer and flush messages into separate files.

- Start two pods that flush to two separate folders. The result shows that it works well
<img width="745" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/d8c62c55-c0de-41e9-bf80-11209bbf5e89">
<img width="1463" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/937988c5-1505-4caf-8f8a-cbd6c6d2b824">
<img width="1328" alt="image" src="https://github.com/streamnative/pulsar-io-cloud-storage/assets/16974619/2b19e901-578f-4898-bf30-b4e4ce85b776">



### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
