### PR TITLE
fix: cleanup the current batch after flush crashed

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -198,7 +198,7 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
     private void flush() {
         if (log.isDebugEnabled()) {
-            log.debug("flush requested, pending: {} ({} bytes}, batchSize: {}, maxBatchBytes: {}",
+            log.debug("flush requested, pending: {} ({} bytes), batchSize: {}, maxBatchBytes: {}",
                 currentBatchSize.get(), currentBatchBytes.get(), maxBatchSize, maxBatchBytes);
         }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSinkTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageGenericRecordSinkTest.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.io.jcloud.format.Format;
 import org.apache.pulsar.io.jcloud.partitioner.Partitioner;
 import org.apache.pulsar.io.jcloud.writer.BlobWriter;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -158,6 +159,24 @@ public class CloudStorageGenericRecordSinkTest {
         this.config.put("batchSize", 1000); // set high batchSize to prevent flush
 
         verifyRecordAck(100);
+    }
+
+    @Test
+    public void testBatchCleanupWhenFlushCrashed() throws Exception {
+        this.config.put("pendingQueueSize", 1000);
+        this.config.put("batchTimeMs", 1000);
+        this.config.put("maxBatchBytes", 5 * PAYLOAD_BYTES);
+        this.config.put("batchSize", 1);
+
+        this.sink.open(this.config, this.mockSinkContext);
+        when(mockRecord.getSchema()).thenThrow(new OutOfMemoryError());
+        sendMockRecord(1);
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(
+                () -> {
+                    Assert.assertEquals(0, this.sink.currentBatchBytes.get());
+                    Assert.assertEquals(0, this.sink.currentBatchSize.get());
+                }
+        );
     }
 
     private void verifyRecordAck(int numberOfRecords) throws Exception {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

In the existing logic, whether the flush operation fails or succeeds, the variables `currentBatchSize` and `currentBatchBytes` will be cleared. However, if an error such as an Out of Memory (OOM) exception occurs during the flush operation, it will be caught here: 
https://github.com/streamnative/pulsar-io-cloud-storage/blob/06d8c33afa7d813ffc2019ed4331a3883f9f9044/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java#L217-L221

Nonetheless, the batch might not be cleared properly. This could result in an empty queue, despite `currentBatchSize` and `currentBatchBytes` not being reset to 0.

### Modifications

- The batch is now cleared before the actual flush operation takes place.

### Verifying this change


This change added tests。

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
