### PR TITLE
[feat][Proposal-2] Support including the topic name to the metadata(#836)

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -114,6 +114,7 @@ public class BlobStoreAbstractConfig implements Serializable {
     private boolean withMetadata;
     private boolean useHumanReadableMessageId;
     private boolean useHumanReadableSchemaVersion;
+    private boolean includeTopicToMetadata;
     private boolean withTopicPartitionNumber = true;
     private String bytesFormatTypeSeparator = "0x10";
     private boolean skipFailedMessages = false;

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/AvroFormat.java
@@ -53,6 +53,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
     private boolean useHumanReadableSchemaVersion;
+    private boolean includeTopicToMetadata;
     private CodecFactory codecFactory;
 
     @Override
@@ -65,6 +66,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
         this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
+        this.includeTopicToMetadata = configuration.isIncludeTopicToMetadata();
         String codecName = configuration.getAvroCodec();
         if (codecName == null) {
             this.codecFactory = CodecFactory.nullCodec();
@@ -86,7 +88,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
         rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
         if (useMetadata){
             rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema,
-                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
+                    useHumanReadableMessageId, useHumanReadableSchemaVersion, includeTopicToMetadata);
         }
 
         LOGGER.debug("Using avro schema: {}", rootAvroSchema);
@@ -124,7 +126,7 @@ public class AvroFormat implements Format<GenericRecord> , InitConfiguration<Blo
                 if (useMetadata) {
                     org.apache.avro.generic.GenericRecord metadataRecord =
                             MetadataUtil.extractedMetadataRecord(next,
-                                    useHumanReadableMessageId, useHumanReadableSchemaVersion);
+                                    useHumanReadableMessageId, useHumanReadableSchemaVersion, includeTopicToMetadata);
                     writeRecord.put(MetadataUtil.MESSAGE_METADATA_KEY, metadataRecord);
                 }
                 fileWriter.append(writeRecord);

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/JsonFormat.java
@@ -68,6 +68,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
     private boolean useHumanReadableSchemaVersion;
+    private boolean includeTopicToMetadata;
 
     @Override
     public String getExtension() {
@@ -79,6 +80,7 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
         this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
+        this.includeTopicToMetadata = configuration.isIncludeTopicToMetadata();
 
         if (configuration.isJsonAllowNaN()) {
             JSON_MAPPER.get().enable(ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
@@ -117,7 +119,8 @@ public class JsonFormat implements Format<GenericRecord>, InitConfiguration<Blob
             Map<String, Object> writeValue = convertRecordToObject(next.getValue(), schema);
             if (useMetadata) {
                 writeValue.put(MetadataUtil.MESSAGE_METADATA_KEY,
-                        MetadataUtil.extractedMetadata(next, useHumanReadableMessageId, useHumanReadableSchemaVersion));
+                        MetadataUtil.extractedMetadata(next, useHumanReadableMessageId, useHumanReadableSchemaVersion,
+                                includeTopicToMetadata));
             }
             String recordAsString = JSON_MAPPER.get().writeValueAsString(writeValue);
             stringBuilder.append(recordAsString).append("\n");

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/ParquetFormat.java
@@ -63,6 +63,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
     private boolean useMetadata;
     private boolean useHumanReadableMessageId;
     private boolean useHumanReadableSchemaVersion;
+    private boolean includeTopicToMetadata;
 
     private CompressionCodecName compressionCodecName = CompressionCodecName.GZIP;
 
@@ -76,6 +77,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
         this.useMetadata = configuration.isWithMetadata();
         this.useHumanReadableMessageId = configuration.isUseHumanReadableMessageId();
         this.useHumanReadableSchemaVersion = configuration.isUseHumanReadableSchemaVersion();
+        this.includeTopicToMetadata = configuration.isIncludeTopicToMetadata();
         this.compressionCodecName = CompressionCodecName.fromConf(configuration.getParquetCodec());
     }
 
@@ -185,7 +187,7 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                 rootAvroSchema = AvroRecordUtil.convertToAvroSchema(schema);
                 if (useMetadata) {
                     rootAvroSchema = MetadataUtil.setMetadataSchema(rootAvroSchema,
-                            useHumanReadableMessageId, useHumanReadableSchemaVersion);
+                            useHumanReadableMessageId, useHumanReadableSchemaVersion, includeTopicToMetadata);
                 }
                 log.info("Using avro schema: {}", rootAvroSchema);
             }
@@ -268,7 +270,9 @@ public class ParquetFormat implements Format<GenericRecord>, InitConfiguration<B
                     if (useMetadata) {
                         org.apache.avro.generic.GenericRecord metadataRecord =
                                 MetadataUtil.extractedMetadataRecord(next,
-                                        useHumanReadableMessageId, useHumanReadableSchemaVersion);
+                                        useHumanReadableMessageId,
+                                        useHumanReadableSchemaVersion,
+                                        includeTopicToMetadata);
                         writeRecord.put(MESSAGE_METADATA_KEY, metadataRecord);
                     }
                     if (parquetWriter != null) {

--- a/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/MetadataUtilTest.java
@@ -44,6 +44,7 @@ public class MetadataUtilTest {
         String messageIdString = "1:2:3:4";
         byte[] schemaVersionBytes = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A};
         byte[] messageIdBytes = new byte[]{0x00, 0x01, 0x02, 0x03};
+        String topicName = "test-topic";
         Record<GenericRecord> mockRecord = mock(Record.class);
         Message<GenericRecord> mockMessage = mock(Message.class);
         MessageId mockMessageId = mock(MessageId.class);
@@ -53,23 +54,25 @@ public class MetadataUtilTest {
         when(mockMessage.getSchemaVersion()).thenReturn(schemaVersionBytes);
         when(mockMessageId.toString()).thenReturn(messageIdString);
         when(mockMessageId.toByteArray()).thenReturn(messageIdBytes);
+        when(mockMessage.getTopicName()).thenReturn(topicName);
 
         Map<String, Object> metadataWithHumanReadableMetadata =
-                MetadataUtil.extractedMetadata(mockRecord, true, true);
+                MetadataUtil.extractedMetadata(mockRecord, true, true, true);
         Assert.assertEquals(metadataWithHumanReadableMetadata.get(METADATA_MESSAGE_ID_KEY), messageIdString);
         Assert.assertNotEquals(metadataWithHumanReadableMetadata.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
         Assert.assertEquals(metadataWithHumanReadableMetadata.get(METADATA_SCHEMA_VERSION_KEY),
                 MetadataUtil.parseSchemaVersionFromBytes(schemaVersionBytes));
+        Assert.assertEquals(metadataWithHumanReadableMetadata.get(MetadataUtil.METADATA_TOPIC), topicName);
 
         Map<String, Object> metadataWithHumanReadableMessageId =
-                MetadataUtil.extractedMetadata(mockRecord, true, false);
+                MetadataUtil.extractedMetadata(mockRecord, true, false, false);
         Assert.assertEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY), messageIdString);
         Assert.assertNotEquals(metadataWithHumanReadableMessageId.get(METADATA_MESSAGE_ID_KEY),
                 ByteBuffer.wrap(messageIdBytes));
 
 
-        Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false, false);
+        Map<String, Object> metadata = MetadataUtil.extractedMetadata(mockRecord, false, false, false);
         Assert.assertEquals(metadata.get(METADATA_MESSAGE_ID_KEY), ByteBuffer.wrap(messageIdBytes));
         Assert.assertEquals(metadata.get(METADATA_SCHEMA_VERSION_KEY), schemaVersionBytes);
         Assert.assertNotEquals(metadata.get(METADATA_MESSAGE_ID_KEY), messageIdString);


### PR DESCRIPTION
Proposal link: https://github.com/streamnative/pulsar-io-cloud-storage/pull/860

Special release for https://github.com/streamnative/pulsar-io-cloud-storage/issues/816

See https://github.com/streamnative/pulsar-io-cloud-storage/issues/816

- Add new configuration `includeTopicToMetadata`

(cherry picked from commit 94620e41f2e0d1b03bf98c5914359016153b11b9)


<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation

Currently, we don't include the topic name to the metadata. And there is not intuitive workaround for it.

This proposal introduces a new configuration `includeTopicName` to the Cloud Storage sink connector. When
activated(`true`), the connector will include the topic name to the metadata in the sink file.

### Modifications

Introduce a new configuration `includeTopicToMetadata` to support including the Pulsar topic name into the metadata.

The new data format of the cloud storage format would be like:

```json
{
  "key": "value",
  "__message_metadata__": {
    "messageId": "CAgQADAA",
    "topic": "persistent://public/default/test-s3",
    "properties": {}
  }
}
```

A new key, `topic`, would be added to the metadata, containing the Pulsar topic name.

### Tests

```
{"test-message":"test-value","__message_metadata__":{"messageId":"17:0:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:1:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:2:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:3:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:4:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:5:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:6:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:7:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:8:-1","topic":"persistent://public/default/test-s3","properties":{}}}
{"test-message":"test-value","__message_metadata__":{"messageId":"17:9:-1","topic":"persistent://public/default/test-s3","properties":{}}}

```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (10MB)*
- *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs?

- [x] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [ ] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
