### PR TITLE
Add default value for the partitionType to `partition`

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -83,7 +83,7 @@ public class BlobStoreAbstractConfig implements Serializable {
     private String formatType;
 
     @Deprecated // Use partitioner instead
-    private String partitionerType;
+    private String partitionerType = "partition";
     private PartitionerType partitioner = PartitionerType.LEGACY;
 
     private boolean partitionerUseIndexAsOffset;


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

In https://github.com/streamnative/pulsar-io-cloud-storage/pull/845, we have deprecated `partitionerType` and recommand users to use `partitioner`.

Set the default value of `partitionerType` to `partition`. So that we could be able to not configure it. Otherwise, it will raise exceptions if we don't configure it.

### Modifications

- Add default value for the partitionType to `partition`

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
