### PR TITLE
Use the Apache images to run tests, in order to avoid permission issues.

### DIFF
--- a/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
@@ -75,7 +75,7 @@ public abstract class PulsarTestBase {
         log.info("-------------------------------------------------------------------------");
 
 
-        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "streamnative/pulsar:2.9.2.13");
+        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "apachepulsar/pulsar:latest");
         pulsarService = new PulsarContainer(DockerImageName.parse(pulsarImage));
         pulsarService.waitingFor(new HttpWaitStrategy()
                 .forPort(BROKER_HTTP_PORT)

--- a/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
@@ -32,9 +32,9 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public static final int BROKER_HTTP_PORT = 8080;
     public static final String METRICS_ENDPOINT = "/metrics";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("streamnative/pulsar");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("apachepulsar/pulsar");
     @Deprecated
-    private static final String DEFAULT_TAG = "2.8.1.6";
+    private static final String DEFAULT_TAG = "latest";
 
     private boolean functionsWorkerEnabled = false;
 
@@ -57,7 +57,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public PulsarContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
 
-        dockerImageName.assertCompatibleWith(DockerImageName.parse("streamnative/pulsar"));
+        dockerImageName.assertCompatibleWith(DockerImageName.parse("apachepulsar/pulsar"));
 
         withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
         withCommand("/pulsar/bin/pulsar", "standalone", "--no-functions-worker", "-nss");


### PR DESCRIPTION
### Motivation
Fix ci: https://github.com/streamnative/pulsar-io-cloud-storage/actions/runs/8533562615/job/23376542105?pr=935


### Modifications
- Use the Apache images to run tests, in order to avoid permission issues.


### Verifying this change
Ci passed

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
