### PR TITLE
[fix]: fix Parquet/Avro format with separated key value avro-avro messages

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,10 +18,10 @@ jobs:
         java-version: 17
 
     - name: Code check
-      run: mvn license:check checkstyle:check spotbugs:check
+      run: mvn license:check spotbugs:check
 
     - name: Build with Maven
-      run: mvn install test -DfailIfNoTests=false
+       run: mvn install test -DfailIfNoTests=false -Dcheckstyle.skip
 
     - name: package surefire artifacts
       if: failure()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,7 +21,7 @@ jobs:
       run: mvn license:check spotbugs:check
 
     - name: Build with Maven
-       run: mvn install test -DfailIfNoTests=false -Dcheckstyle.skip
+      run: mvn install test -DfailIfNoTests=false -Dcheckstyle.skip
 
     - name: package surefire artifacts
       if: failure()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,10 +18,10 @@ jobs:
         java-version: 17
 
     - name: Code check
-      run: mvn license:check spotbugs:check
+      run: mvn license:check checkstyle:check spotbugs:check
 
     - name: Build with Maven
-      run: mvn install test -DfailIfNoTests=false -Dcheckstyle.skip
+      run: mvn install test -DfailIfNoTests=false
 
     - name: package surefire artifacts
       if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <!-- connector dependencies -->
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.4.2</jackson-databind.version>
-    <lombok.version>1.18.20</lombok.version>
+    <lombok.version>1.18.32</lombok.version>
     <pulsar.version>3.2.2.1</pulsar.version>
     <avro.version>1.11.3</avro.version>
     <hadoop.version>3.3.6</hadoop.version>

--- a/src/main/java/org/apache/pulsar/io/jcloud/format/BytesFormat.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/format/BytesFormat.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.jcloud.format;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
@@ -35,6 +36,7 @@ import org.apache.pulsar.jcloud.shade.com.google.common.io.ByteStreams;
  */
 public class BytesFormat implements Format<GenericRecord>, InitConfiguration<BlobStoreAbstractConfig> {
 
+    public static final byte[] NULL_BYTES = "".getBytes(StandardCharsets.UTF_8);
     private byte[] lineSeparatorBytes;
 
     @Override
@@ -62,7 +64,10 @@ public class BytesFormat implements Format<GenericRecord>, InitConfiguration<Blo
         while (record.hasNext()) {
             final Record<GenericRecord> next = record.next();
             final Message<GenericRecord> message = next.getMessage().get();
-            final byte[] data = message.getData();
+            byte[] data = message.getData();
+            if (data == null) {
+                data = NULL_BYTES;
+            }
             dataOutput.write(data);
             dataOutput.write(lineSeparatorBytes);
         }

--- a/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/util/AvroRecordUtil.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericProtobufNativeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
@@ -168,8 +169,10 @@ public class AvroRecordUtil {
 
             final Schema avroSchema = Schema.createRecord("KVSchema", null, null, false,
                     Arrays.asList(
-                            new Schema.Field("key", parseAvroSchema(keySchemaDef)),
-                            new Schema.Field("value", parseAvroSchema(valueSchemaDef))
+                            // namespace+name must be different in the KVSchema
+                            new Schema.Field("key", parseAvroSchema(keySchemaDef, "_key")),
+                            new Schema.Field("value", Schema.createUnion(
+                                    Schema.create(Schema.Type.NULL), parseAvroSchema(valueSchemaDef, "_value")))
                     ));
             return avroSchema;
         } else {
@@ -181,14 +184,24 @@ public class AvroRecordUtil {
             if (StringUtils.isEmpty(rootAvroSchemaString)) {
                 throw new IllegalArgumentException("schema definition is empty");
             }
-            return parseAvroSchema(rootAvroSchemaString);
+            return parseAvroSchema(rootAvroSchemaString, null);
         }
     }
 
-    private static Schema parseAvroSchema(String jsonSchema) {
+    private static Schema parseAvroSchema(String jsonSchema, String namespaceSuffix) {
         final Schema.Parser parser = new Schema.Parser();
         parser.setValidateDefaults(false);
-        return parser.parse(jsonSchema);
+        Schema schema = parser.parse(jsonSchema);
+        List<Schema.Field> fields = schema.getFields()
+                .stream()
+                .map(f -> new Schema.Field(f, f.schema()))
+                .collect(Collectors.toList());
+        if (namespaceSuffix == null) {
+            namespaceSuffix = "";
+        }
+        final String namespace = schema.getNamespace() == null
+                ? namespaceSuffix : schema.getNamespace() + namespaceSuffix;
+        return Schema.createRecord(schema.getName(), null, namespace, false, fields);
     }
 
     public static org.apache.avro.generic.GenericRecord convertGenericRecord(DynamicMessage recordValue,
@@ -215,6 +228,30 @@ public class AvroRecordUtil {
 
     public static org.apache.avro.generic.GenericRecord convertGenericRecord(GenericRecord recordValue,
                                                                              Schema rootAvroSchema) {
+        if (recordValue.getSchemaType() == SchemaType.KEY_VALUE) {
+            KeyValue<GenericRecord, GenericRecord> keyValue =
+                    (KeyValue<GenericRecord, GenericRecord>) recordValue.getNativeObject();
+            org.apache.avro.generic.GenericRecord recordHolder = new GenericData.Record(rootAvroSchema);
+            GenericRecord keyObject = keyValue.getKey();
+            if (keyObject != null) {
+                Schema keySchema = rootAvroSchema.getField("key").schema();
+                recordHolder.put("key", convertGenericRecord(keyObject, keySchema));
+            }
+            GenericRecord valueObject = keyValue.getValue();
+            if (valueObject != null) {
+                Schema valueSchema = rootAvroSchema.getField("value").schema();
+                recordHolder.put("value", convertGenericRecord(valueObject, valueSchema));
+            }
+            return recordHolder;
+        }
+
+        // handle nullable fields that are union[null,record]
+        if (rootAvroSchema.isUnion()) {
+            rootAvroSchema = rootAvroSchema.getTypes().stream()
+                    .filter(schema -> schema.getType().equals(Schema.Type.RECORD))
+                    .findFirst()
+                    .get();
+        }
         org.apache.avro.generic.GenericRecord recordHolder = new GenericData.Record(rootAvroSchema);
         for (org.apache.pulsar.client.api.schema.Field field : recordValue.getFields()) {
             Schema.Field field1 = rootAvroSchema.getField(field.getName());


### PR DESCRIPTION
### Motivation

To fix the Parquet/Avro format with separated key value avro-avro messages

### Modifications

Updated lombook version.
Parquet/Avro format with separated key value avro-avro messages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
