### PR TITLE
Fix duplication file name for batch message

### DIFF
--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.partitioner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.functions.api.Record;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractPartitionerTest {
+
+    @Test
+    public void testGetMessageOffsetWithBatchMessage() {
+
+        AbstractPartitioner<Object> abstractPartitioner = new AbstractPartitioner<>() {
+            @Override
+            public String encodePartition(Record<Object> sinkRecord) {
+                return null;
+            }
+        };
+
+        BatchMessageIdImpl batchId1 = new BatchMessageIdImpl(12, 34, 1, 1);
+        Record<Object> message1 = getMessageRecord(batchId1);
+
+        BatchMessageIdImpl batchId2 = new BatchMessageIdImpl(12, 34, 1, 2);
+        Record<Object> message2 = getMessageRecord(batchId2);
+
+        Assert.assertNotEquals(abstractPartitioner.getMessageOffset(message1),
+                abstractPartitioner.getMessageOffset(message2));
+
+        MessageIdImpl id3 = new MessageIdImpl(12, 34, 1);
+        Assert.assertEquals(abstractPartitioner.getMessageOffset(getMessageRecord(id3)), 3221225506L);
+    }
+
+    public static Record<Object> getMessageRecord(MessageId msgId) {
+        @SuppressWarnings("unchecked")
+        Message<Object> mock = mock(Message.class);
+        when(mock.getPublishTime()).thenReturn(1599578218610L);
+        when(mock.getMessageId()).thenReturn(msgId);
+        when(mock.hasIndex()).thenReturn(true);
+        when(mock.getIndex()).thenReturn(Optional.of(11115506L));
+
+        String topic = TopicName.get("test").toString();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
+    }
+
+}


### PR DESCRIPTION
### Motivation
If sink batch message, will get an error for azure blob storage:
```
2024-11-04T01:43:57,072+0000 [pulsar-io-cloud-storage-sink-flush-0] ERROR org.apache.pulsar.io.jcloud.sink.BlobStoreAbstractSink - Encountered unknown error writing to blob abhijith/testing-eh-kaka-sync/unbuffered-telemetryfeed-partition-28/2024-10-30/799132352513.json
com.azure.storage.blob.models.BlobStorageException: Status code 409, "﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>BlobAlreadyExists</Code><Message>The specified blob already exists.
RequestId:4506238d-001e-00df-085b-2eae40000000
Time:2024-11-04T01:43:57.0681430Z</Message></Error>"
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732) ~[?:?]
	at com.azure.core.implementation.MethodHandleReflectiveInvoker.invokeWithArguments(MethodHandleReflectiveInvoker.java:39) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.ResponseExceptionConstructorCache.invoke(ResponseExceptionConstructorCache.java:53) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.RestProxyBase.instantiateUnexpectedException(RestProxyBase.java:411) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.AsyncRestProxy.lambda$ensureExpectedStatus$1(AsyncRestProxy.java:132) ~[azure-core-1.47.0.jar:1.47.0]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:113) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2400) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:171) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2196) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2070) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onNext(FluxHide.java:137) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onNext(FluxHide.java:137) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1839) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1839) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoCreate$DefaultMonoSink.success(MonoCreate.java:172) ~[reactor-core-3.4.34.jar:3.4.34]
```

The root cause is here used `getSequence`

https://github.com/streamnative/pulsar-io-cloud-storage/blob/4b94112ef8b84af9b9390dbf02168b834870657c/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java#L95-L96

But, in pulsar, just use `LedgerId` + `EntryId` to gen sequence

https://github.com/apache/pulsar/blob/bbc62245c5ddba1de4b1e7cee4ab49334bc36277/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java#L289-L299



### Modifications
- Reimpl this logic on this connector to quick fix: if a message is a batch, will add batchIndex.

### Verifying this change
- Add AbstractPartitionerTest to cover it, and verify on my localhost

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
