### PR TITLE
Use messageId instead of sequence as file name by default

### DIFF
--- a/docs/aws-s3-sink.md
+++ b/docs/aws-s3-sink.md
@@ -236,9 +236,8 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
-  this file.
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.

--- a/docs/aws-s3-sink.md
+++ b/docs/aws-s3-sink.md
@@ -236,9 +236,9 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest message offset in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest message offset in
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
   this file.

--- a/docs/azure-blob-storage-sink.md
+++ b/docs/azure-blob-storage-sink.md
@@ -223,9 +223,8 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
-  this file.
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.

--- a/docs/azure-blob-storage-sink.md
+++ b/docs/azure-blob-storage-sink.md
@@ -223,9 +223,9 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest message offset in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest message offset in
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
   this file.

--- a/docs/google-cloud-storage-sink.md
+++ b/docs/google-cloud-storage-sink.md
@@ -222,9 +222,8 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
-  this file.
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId(Format: `ledgerId.entryId.batchIndex`)/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.

--- a/docs/google-cloud-storage-sink.md
+++ b/docs/google-cloud-storage-sink.md
@@ -222,9 +222,9 @@ There are two types of partitioner:
 - **PARTITION**: This is the default partitioning method based on Pulsar partitions. In other words, data is
   partitioned according to the pre-existing partitions in Pulsar topics. For instance, a message for the
   topic `public/default/my-topic-partition-0` would be directed to the
-  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest message offset in this file.
+  file `public/default/my-topic-partition-0/xxx.json`, where `xxx` signifies the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in this file.
 
 - **TIME**: Data is partitioned according to the time it was flushed. Using the previous message as an
   example, if it was received on 2023-12-20, it would be directed
-  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest message offset in
+  to `public/default/my-topic-partition-0/2023-12-20/xxx.json`, where `xxx` also denotes the earliest messageId/offset(Enable config: `partitionerUseIndexAsOffset`) in
   this file.

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
@@ -73,7 +73,7 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
         return StringUtils.join(joinList, PATH_SEPARATOR);
     }
 
-    protected long getMessageOffset(Record<T> record) {
+    protected String getFileName(Record<T> record) {
         if (useIndexAsOffset && record.getMessage().isPresent()) {
             final Message<T> message = record.getMessage().get();
             // Use index added by org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor if present.
@@ -81,7 +81,7 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
             if (message.hasIndex()) {
                 final Optional<Long> index = message.getIndex();
                 if (index.isPresent()) {
-                    return index.get();
+                    return String.valueOf(index.get());
                 } else {
                     LOGGER.warn("Found message {} with hasIndex=true but index is empty, using recordSequence",
                             message.getMessageId());
@@ -92,7 +92,9 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
                         message.getMessageId());
             }
         }
-        return record.getRecordSequence()
-                .orElseThrow(() -> new RuntimeException("found empty recordSequence"));
+        return record.getMessage()
+                .map(msg -> msg.getMessageId().toString())
+                .orElseThrow(() -> new RuntimeException("found empty message"));
     }
+
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
@@ -93,8 +94,11 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
             }
         }
         return record.getMessage()
-                .map(msg -> msg.getMessageId().toString())
+                .map(msg -> (MessageIdAdv) msg.getMessageId())
+                .map(msgId -> String.format("%s.%s.%s",
+                        msgId.getLedgerId(), msgId.getEntryId(), msgId.getBatchIndex()))
                 .orElseThrow(() -> new RuntimeException("found empty message"));
+
     }
 
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/SimplePartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/SimplePartitioner.java
@@ -29,6 +29,6 @@ public class SimplePartitioner<T> extends AbstractPartitioner<T> {
 
     @Override
     public String encodePartition(Record<T> sinkRecord) {
-        return Long.toString(getMessageOffset(sinkRecord));
+        return getFileName(sinkRecord);
     }
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/TimePartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/TimePartitioner.java
@@ -96,7 +96,7 @@ public class TimePartitioner<T> extends AbstractPartitioner<T> {
         String timeString = dateTimeFormatter.format(Instant.ofEpochMilli(parsed).atOffset(ZoneOffset.UTC));
         final String result = timeString
                 + PATH_SEPARATOR
-                + getMessageOffset(sinkRecord);
+                + getFileName(sinkRecord);
         return result;
     }
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -224,7 +224,7 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
         String encodePartition = partitioner.encodePartition(message, partitioningTimestamp);
         String partitionedPath = partitioner.generatePartitionedPath(message.getTopicName().get(), encodePartition);
         String path = sinkConfig.getPathPrefix() + partitionedPath + format.getExtension();
-        log.info("generate message[recordSequence={}] savePath: {}", message.getRecordSequence().get(), path);
+        log.info("generate message[messageId={}] savePath: {}", message.getMessage().get().getMessageId(), path);
         return path;
     }
 }

--- a/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/writer/AzureBlobWriter.java
@@ -63,7 +63,11 @@ public class AzureBlobWriter implements BlobWriter {
     @Override
     public void uploadBlob(String key, ByteBuffer payload) throws IOException {
         BlobClient blobClient = this.containerClient.getBlobClient(key);
-        blobClient.upload(BinaryData.fromBytes(payload.array()));
+        // Allow overwriting files. In extreme cases, if the connector restarts,
+        // some messages may have been written to storage but not yet acknowledged.
+        // Then will receive again, the same file names might be generated.
+        // Overwriting these files ensures that messages are not lost and are successfully written.
+        blobClient.upload(BinaryData.fromBytes(payload.array()), true);
     }
 
     @Override

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
@@ -42,20 +42,20 @@ public class AbstractPartitionerTest {
             }
         };
 
-        BatchMessageIdImpl batchId1 = new BatchMessageIdImpl(12, 34, 1, 1);
+        BatchMessageIdImpl batchId1 = new BatchMessageIdImpl(12, 34, -1, 1);
         Record<Object> message1 = getMessageRecord(batchId1);
         String fileName1 = abstractPartitioner.getFileName(message1);
 
-        BatchMessageIdImpl batchId2 = new BatchMessageIdImpl(12, 34, 1, 2);
+        BatchMessageIdImpl batchId2 = new BatchMessageIdImpl(12, 34, -1, 2);
         Record<Object> message2 = getMessageRecord(batchId2);
         String fileName2 = abstractPartitioner.getFileName(message2);
 
-        Assert.assertEquals(fileName1, batchId1.toString());
-        Assert.assertEquals(fileName2, batchId2.toString());
+        Assert.assertEquals(fileName1, "12.34.1");
+        Assert.assertEquals(fileName2, "12.34.2");
         Assert.assertNotEquals(fileName1, fileName2);
 
         MessageIdImpl id3 = new MessageIdImpl(12, 34, 1);
-        Assert.assertEquals(abstractPartitioner.getFileName(getMessageRecord(id3)), "12:34:1");
+        Assert.assertEquals(abstractPartitioner.getFileName(getMessageRecord(id3)), "12.34.-1");
     }
 
     public static Record<Object> getMessageRecord(MessageId msgId) {

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitionerTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.partitioner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.functions.api.Record;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractPartitionerTest {
+
+    @Test
+    public void testGetMessageOffsetWithBatchMessage() {
+
+        AbstractPartitioner<Object> abstractPartitioner = new AbstractPartitioner<>() {
+            @Override
+            public String encodePartition(Record<Object> sinkRecord) {
+                return null;
+            }
+        };
+
+        BatchMessageIdImpl batchId1 = new BatchMessageIdImpl(12, 34, 1, 1);
+        Record<Object> message1 = getMessageRecord(batchId1);
+        String fileName1 = abstractPartitioner.getFileName(message1);
+
+        BatchMessageIdImpl batchId2 = new BatchMessageIdImpl(12, 34, 1, 2);
+        Record<Object> message2 = getMessageRecord(batchId2);
+        String fileName2 = abstractPartitioner.getFileName(message2);
+
+        Assert.assertEquals(fileName1, batchId1.toString());
+        Assert.assertEquals(fileName2, batchId2.toString());
+        Assert.assertNotEquals(fileName1, fileName2);
+
+        MessageIdImpl id3 = new MessageIdImpl(12, 34, 1);
+        Assert.assertEquals(abstractPartitioner.getFileName(getMessageRecord(id3)), "12:34:1");
+    }
+
+    public static Record<Object> getMessageRecord(MessageId msgId) {
+        @SuppressWarnings("unchecked")
+        Message<Object> mock = mock(Message.class);
+        when(mock.getPublishTime()).thenReturn(1599578218610L);
+        when(mock.getMessageId()).thenReturn(msgId);
+        when(mock.hasIndex()).thenReturn(true);
+        when(mock.getIndex()).thenReturn(Optional.of(11115506L));
+
+        String topic = TopicName.get("test").toString();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        return mockRecord;
+    }
+
+}

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -25,6 +25,7 @@ import java.text.MessageFormat;
 import java.util.Optional;
 import junit.framework.TestCase;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
@@ -52,6 +53,8 @@ public class PartitionerTest extends TestCase {
 
     @Parameterized.Parameter(3)
     public Record<Object> pulsarRecord;
+
+    private static final MessageId testMessageId = new MessageIdImpl(12, 34, 1);
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -89,8 +92,8 @@ public class PartitionerTest extends TestCase {
         return new Object[][]{
                 new Object[]{
                         simplePartitioner,
-                        "3221225506",
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getTopic()
                 },
                 new Object[]{
@@ -101,44 +104,44 @@ public class PartitionerTest extends TestCase {
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506"
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
                         , getTopic()
                 },
                 new Object[]{
                         simplePartitioner,
-                        "3221225506",
-                        "public/default/test-partition-1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test-partition-1" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test-partition-1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test-partition-1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506"
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
                         , getPartitionedTopic()
                 },
                 new Object[]{
                         noPartitionNumberPartitioner,
-                        "3221225506",
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         numberPartitioner,
-                        "2020-09-08-14" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test-partition-1/2020-09-08-14" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08-14" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test-partition-1/2020-09-08-14" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
         };
@@ -148,14 +151,13 @@ public class PartitionerTest extends TestCase {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
-        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        when(mock.getMessageId()).thenReturn(testMessageId);
         String topic = TopicName.get("test-partition-1").toString();
         Record<Object> mockRecord = mock(Record.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
         when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
-        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
         return mockRecord;
     }
 
@@ -163,7 +165,7 @@ public class PartitionerTest extends TestCase {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
-        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        when(mock.getMessageId()).thenReturn(testMessageId);
         when(mock.hasIndex()).thenReturn(true);
         when(mock.getIndex()).thenReturn(Optional.of(11115506L));
 
@@ -173,7 +175,6 @@ public class PartitionerTest extends TestCase {
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
         when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
-        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
         return mockRecord;
     }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/PartitionerTest.java
@@ -55,6 +55,7 @@ public class PartitionerTest extends TestCase {
     public Record<Object> pulsarRecord;
 
     private static final MessageId testMessageId = new MessageIdImpl(12, 34, 1);
+    private static final String testMsgIdFileName = "12.34.-1";
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -92,8 +93,8 @@ public class PartitionerTest extends TestCase {
         return new Object[][]{
                 new Object[]{
                         simplePartitioner,
-                        testMessageId.toString(),
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getTopic()
                 },
                 new Object[]{
@@ -104,44 +105,45 @@ public class PartitionerTest extends TestCase {
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName
                         , getTopic()
                 },
                 new Object[]{
                         simplePartitioner,
-                        testMessageId.toString(),
-                        "public/default/test-partition-1" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test-partition-1" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test-partition-1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test-partition-1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test-partition-1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName
                         , getPartitionedTopic()
                 },
                 new Object[]{
                         noPartitionNumberPartitioner,
-                        testMessageId.toString(),
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         numberPartitioner,
-                        "2020-09-08-14" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test-partition-1/2020-09-08-14" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "2020-09-08-14" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test-partition-1/2020-09-08-14"
+                                + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
         };

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
@@ -55,6 +55,7 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
     public Record<Object> pulsarRecord;
 
     private static final MessageId testMessageId = new MessageIdImpl(12, 34, 1);
+    private static final String testMsgIdFileName = "12.34.-1";
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -84,44 +85,44 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
         return new Object[][]{
                 new Object[]{
                         simplePartitioner,
-                        testMessageId.toString(),
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName
                         , getTopic()
                 },
                 new Object[]{
                         simplePartitioner,
-                        testMessageId.toString(),
-                        "public/default/test/1" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test/1" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
-                        "public/default/test/1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
+                        "public/default/test/1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMsgIdFileName
                         , getPartitionedTopic()
                 },
                 new Object[]{
                         noPartitionNumberPartitioner,
-                        testMessageId.toString(),
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        testMsgIdFileName,
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMsgIdFileName,
                         getPartitionedTopic()
                 },
         };

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/SliceTopicPartitionPartitionerTest.java
@@ -25,6 +25,7 @@ import java.text.MessageFormat;
 import java.util.Optional;
 import junit.framework.TestCase;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Record;
@@ -52,6 +53,8 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
 
     @Parameterized.Parameter(3)
     public Record<Object> pulsarRecord;
+
+    private static final MessageId testMessageId = new MessageIdImpl(12, 34, 1);
 
     @Parameterized.Parameters
     public static Object[][] data() {
@@ -81,44 +84,44 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
         return new Object[][]{
                 new Object[]{
                         simplePartitioner,
-                        "3221225506",
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506"
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
                         , getTopic()
                 },
                 new Object[]{
                         simplePartitioner,
-                        "3221225506",
-                        "public/default/test/1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test/1" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         dayPartitioner,
-                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/1/2020-09-08" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
                 new Object[]{
                         hourPartitioner,
-                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506",
-                        "public/default/test/1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + "3221225506"
+                        "2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId,
+                        "public/default/test/1/2020-09-08-12" + Partitioner.PATH_SEPARATOR + testMessageId
                         , getPartitionedTopic()
                 },
                 new Object[]{
                         noPartitionNumberPartitioner,
-                        "3221225506",
-                        "public/default/test" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        testMessageId.toString(),
+                        "public/default/test" + Partitioner.PATH_SEPARATOR + testMessageId,
                         getPartitionedTopic()
                 },
         };
@@ -128,14 +131,13 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
         @SuppressWarnings("unchecked")
         Message<byte[]> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
-        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        when(mock.getMessageId()).thenReturn(testMessageId);
         String topic = TopicName.get("test-partition-1").toString();
         Record<byte[]> mockRecord = mock(Record.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
         when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
-        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
         return mockRecord;
     }
 
@@ -143,14 +145,13 @@ public class SliceTopicPartitionPartitionerTest extends TestCase {
         @SuppressWarnings("unchecked")
         Message<Object> mock = mock(Message.class);
         when(mock.getPublishTime()).thenReturn(1599578218610L);
-        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        when(mock.getMessageId()).thenReturn(testMessageId);
         String topic = TopicName.get("test").toString();
         Record<Object> mockRecord = mock(Record.class);
         when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
         when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
         when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
         when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
-        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
         return mockRecord;
     }
 

--- a/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkBatchBlendTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkBatchBlendTest.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
@@ -98,6 +99,7 @@ public class CloudStorageSinkBatchBlendTest {
 
         Message mockMessage = mock(Message.class);
         when(mockMessage.size()).thenReturn(PAYLOAD_BYTES);
+        when(mockMessage.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
 
         GenericSchema<GenericRecord> schema = createTestSchema();
         GenericRecord genericRecord = spy(createTestRecord(schema));

--- a/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkBatchPartitionedTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/sink/CloudStorageSinkBatchPartitionedTest.java
@@ -172,30 +172,30 @@ public class CloudStorageSinkBatchPartitionedTest {
         }
         await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(10)).untilAsserted(
                 () -> verify(mockBlobWriter, times(1))
-                        .uploadBlob(eq("public/default/topic-1/12:11:1.raw"), any(ByteBuffer.class))
+                        .uploadBlob(eq("public/default/topic-1/12.11.-1.raw"), any(ByteBuffer.class))
         );
-        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-2/12:34:1.raw"), any(ByteBuffer.class));
+        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-2/12.34.-1.raw"), any(ByteBuffer.class));
 
         // 3. Write 2 message for topic-1 again and assert not message need flush(no timeout)
         for (int i = 0; i < 2; i++) {
             sink.write(mockRecordTopic1);
         }
         clearInvocations(mockBlobWriter);
-        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-1/12:11:1.raw"), any(ByteBuffer.class));
+        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-1/12.11.-1.raw"), any(ByteBuffer.class));
 
         // 4. Second sleep maxBatchTimeout / 2 again, and assert topic-2 data need flush
         //    and topic-1 no need flush(no timeout)
         Thread.sleep(maxBatchTimeout / 2 + 100);
         await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(10)).untilAsserted(
                 () -> verify(mockBlobWriter, times(1))
-                        .uploadBlob(eq("public/default/topic-2/12:34:1.raw"), any(ByteBuffer.class))
+                        .uploadBlob(eq("public/default/topic-2/12.34.-1.raw"), any(ByteBuffer.class))
         );
-        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-1/12:11:1.raw"), any(ByteBuffer.class));
+        verify(mockBlobWriter, never()).uploadBlob(eq("public/default/topic-1/12.11.-1.raw"), any(ByteBuffer.class));
 
         // 5. Assert for topic-1 flush data step-3 write data.
         await().atMost(Duration.ofSeconds(10)).untilAsserted(
                 () -> verify(mockBlobWriter, times(1))
-                        .uploadBlob(eq("public/default/topic-1/12:11:1.raw"), any(ByteBuffer.class))
+                        .uploadBlob(eq("public/default/topic-1/12.11.-1.raw"), any(ByteBuffer.class))
         );
 
         // 6. Assert all message has been ack
@@ -313,7 +313,7 @@ public class CloudStorageSinkBatchPartitionedTest {
 
         await().atMost(Duration.ofSeconds(10)).untilAsserted(
                 () -> verify(mockBlobWriter, times(1))
-                        .uploadBlob(eq("public/default/topic-2/12:34:1.raw"), any(ByteBuffer.class))
+                        .uploadBlob(eq("public/default/topic-2/12.34.-1.raw"), any(ByteBuffer.class))
         );
         await().atMost(Duration.ofSeconds(30)).untilAsserted(
                 () -> verify(mockRecordTopic2, times(5)).ack()
@@ -322,7 +322,7 @@ public class CloudStorageSinkBatchPartitionedTest {
         this.sink.write(mockRecordTopic1);
         await().atMost(Duration.ofSeconds(10)).untilAsserted(
                 () -> verify(mockBlobWriter, times(1))
-                        .uploadBlob(eq("public/default/topic-1/12:11:1.raw"), any(ByteBuffer.class))
+                        .uploadBlob(eq("public/default/topic-1/12.11.-1.raw"), any(ByteBuffer.class))
         );
         await().atMost(Duration.ofSeconds(30)).untilAsserted(
                 () -> verify(mockRecordTopic1, times(5)).ack()


### PR DESCRIPTION
### Motivation

For azure blob storage, When sink some batch message, somtime will get an error for azure blob storage:
```
2024-11-04T01:43:57,072+0000 [pulsar-io-cloud-storage-sink-flush-0] ERROR org.apache.pulsar.io.jcloud.sink.BlobStoreAbstractSink - Encountered unknown error writing to blob abhijith/testing-eh-kaka-sync/unbuffered-telemetryfeed-partition-28/2024-10-30/799132352513.json
com.azure.storage.blob.models.BlobStorageException: Status code 409, "﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>BlobAlreadyExists</Code><Message>The specified blob already exists.
RequestId:4506238d-001e-00df-085b-2eae40000000
Time:2024-11-04T01:43:57.0681430Z</Message></Error>"
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732) ~[?:?]
	at com.azure.core.implementation.MethodHandleReflectiveInvoker.invokeWithArguments(MethodHandleReflectiveInvoker.java:39) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.ResponseExceptionConstructorCache.invoke(ResponseExceptionConstructorCache.java:53) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.RestProxyBase.instantiateUnexpectedException(RestProxyBase.java:411) ~[azure-core-1.47.0.jar:1.47.0]
	at com.azure.core.implementation.http.rest.AsyncRestProxy.lambda$ensureExpectedStatus$1(AsyncRestProxy.java:132) ~[azure-core-1.47.0.jar:1.47.0]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:113) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2400) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:171) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2196) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2070) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onNext(FluxHide.java:137) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onNext(FluxHide.java:137) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1839) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1839) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.34.jar:3.4.34]
	at reactor.core.publisher.MonoCreate$DefaultMonoSink.success(MonoCreate.java:172) ~[reactor-core-3.4.34.jar:3.4.34]
```

For AWS s3, will overwrite file: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html

The root cause is here used `getSequence`

https://github.com/streamnative/pulsar-io-cloud-storage/blob/4b94112ef8b84af9b9390dbf02168b834870657c/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java#L95-L96

And then, in pulsar, just use `LedgerId` + `EntryId` to gen sequence.

https://github.com/apache/pulsar/blob/bbc62245c5ddba1de4b1e7cee4ab49334bc36277/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java#L289-L299

So, maybe get the same file name for two flush request.

### Modifications

Currently, the implementation is not clear. For example, a file named `3221225506.json` is difficult for users to understand in terms of the sequence's meaning.

The connectors we are currently running may have data being overwritten, leading to potential loss.

It would be better to directly use the `messageId `for clarity. If using a long type is insufficient to represent `ledgerId + entryId + batchIndex`


- Return messageId by default. the file name format is: xx/xx/xx/18:2:1:24.json.

### Verifying this change
- Add AbstractPartitionerTest to cover it, and verify on my localhost

<img width="2233" alt="image" src="https://github.com/user-attachments/assets/c4c99433-3ff4-4818-82cf-7c9cbe53ddfc">



### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [] `no-need-doc`

  (Please explain why)

- [x] `doc`

  (If this PR contains doc changes)
