### PR TITLE
Upgrade netty to fix CVE-2024-47535

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <reload4j.version>1.2.24</reload4j.version>
     <woodstox-core.version>5.4.0</woodstox-core.version>
-    <netty.version>4.1.86.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <libthrift.version>0.17.0</libthrift.version>
   </properties>
 


### PR DESCRIPTION
### Motivation
- https://github.com/streamnative/eng-support-tickets/issues/1987
- https://github.com/streamnative/eng-support-tickets/issues/1988

### Modifications
- Upgrade netty to fix CVE-2024-47535


### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
