### PR TITLE
Support multi-arch connector image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Login streamnative docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set project version
         run: |
           project_version=${GITHUB_REF#refs/tags/v}
@@ -38,13 +44,16 @@ jobs:
         with:
           max_attempts: 99
           retry_wait_seconds: 60
-          timeout_minutes: 5
+          timeout_minutes: 30
           command: |
             CONNECTOR_VERSION=`./scripts/get-version.sh`
             PULSAR_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${pulsar.version}' --non-recursive exec:exec 2>/dev/null`
             REPO=`mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' --non-recursive exec:exec 2>/dev/null`
             IMAGE_REPO=streamnative/${REPO}
-            RUNNER_IMAGE=streamnative/pulsar-functions-java-runner:${PULSAR_VERSION}
-            docker pull ${RUNNER_IMAGE}
-            docker build --build-arg PULSAR_VERSION="$PULSAR_VERSION" -t ${IMAGE_REPO}:${CONNECTOR_VERSION} -f ./image/Dockerfile ./
-            docker push ${IMAGE_REPO}:${CONNECTOR_VERSION}
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg PULSAR_VERSION="$PULSAR_VERSION" \
+              -t ${IMAGE_REPO}:${CONNECTOR_VERSION} \
+              -f ./image/Dockerfile \
+              --push \
+              ./

--- a/pom.xml
+++ b/pom.xml
@@ -45,23 +45,24 @@
     <testRetryCount>2</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.13.2</jackson.version>
-    <jackson-databind.version>2.13.4.2</jackson-databind.version>
-    <lombok.version>1.18.32</lombok.version>
-    <pulsar.version>4.0.4.2</pulsar.version>
-    <avro.version>1.11.4</avro.version>
+    <jackson.version>2.18.6</jackson.version>
+    <jackson-databind.version>2.18.6</jackson-databind.version>
+    <lombok.version>1.18.42</lombok.version>
+    <pulsar.version>4.2.0.6</pulsar.version>
+    <jclouds-shaded.version>4.0.4.2</jclouds-shaded.version>
+    <avro.version>1.12.0</avro.version>
     <hadoop.version>3.3.6</hadoop.version>
     <parquet.version>1.13.1</parquet.version>
-    <awsjavasdk.version>1.12.698</awsjavasdk.version>
-    <aws.java.sdk2.version>2.16.104</aws.java.sdk2.version>
+    <awsjavasdk.version>1.12.788</awsjavasdk.version>
+    <aws.java.sdk2.version>2.32.28</aws.java.sdk2.version>
     <jaxb-api>2.3.1</jaxb-api>
-    <gson.version>2.8.9</gson.version>
-    <commons-compress.version>1.26.0</commons-compress.version>
+    <gson.version>2.13.2</gson.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
     <log4j.version>2.17.1</log4j.version>
     <json-smart.version>2.4.9</json-smart.version>
     <protobuf3.version>3.25.5</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.42.1</grpc.version>
+    <grpc.version>1.75.0</grpc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <azure-sdk-bom.version>1.2.22</azure-sdk-bom.version>
 
@@ -86,7 +87,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <reload4j.version>1.2.24</reload4j.version>
     <woodstox-core.version>5.4.0</woodstox-core.version>
-    <netty.version>4.1.115.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <libthrift.version>0.17.0</libthrift.version>
   </properties>
 
@@ -127,6 +128,21 @@
         <version>${jackson-databind.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson-databind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson-databind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson-databind.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>${jackson.version}</version>
@@ -144,7 +160,7 @@
       <dependency>
         <groupId>io.streamnative</groupId>
         <artifactId>jclouds-shaded</artifactId>
-        <version>${pulsar.version}</version>
+        <version>${jclouds-shaded.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Fixes https://github.com/streamnative/product-roadmap/issues/1572

## Summary
- Upgrade the connector runtime to Pulsar `4.2.0.6` and align shared dependency versions with Pulsar `branch-4.2` where applicable.
- Update release image workflows to use Buildx/QEMU and publish `linux/amd64,linux/arm64` images.
- Keep existing test boundaries unchanged; this PR does not add Surefire test excludes or change unit-test workflow commands.

## Validation
- `mvn clean install -DskipTests`
- workflow YAML parse check
- `git diff --check`

Note: after keeping the original test boundaries, `mvn test -Dtest="*Test" -DfailIfNoTests=false` may reach existing external integration tests in some connectors and requires their normal external services, such as Docker/Testcontainers or LocalStack.